### PR TITLE
feat(account): deletion + provider label + verify

### DIFF
--- a/CineMate/CineMate.xcodeproj/project.pbxproj
+++ b/CineMate/CineMate.xcodeproj/project.pbxproj
@@ -103,6 +103,8 @@
 		0359A97A2E02F17400818BD2 /* PreviewStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0359A9792E02F17400818BD2 /* PreviewStyle.swift */; };
 		0359A97D2E03488000818BD2 /* CastViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0359A97C2E03488000818BD2 /* CastViewModel.swift */; };
 		035CB2C02E51CA6500892271 /* AuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035CB2BF2E51CA6500892271 /* AuthViewModel.swift */; };
+		03618C2F2E68DB1100D75D10 /* FirebaseAuthService+Deletion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03618C2E2E68DB1100D75D10 /* FirebaseAuthService+Deletion.swift */; };
+		03618C312E68E79D00D75D10 /* AccountDangerZoneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03618C302E68E79D00D75D10 /* AccountDangerZoneView.swift */; };
 		03623F232E2D6E6E00066528 /* PreviewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03623F222E2D6E6E00066528 /* PreviewHelpers.swift */; };
 		03652CE52DFC56830031DCAD /* MovieDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03652CE42DFC56830031DCAD /* MovieDetail.swift */; };
 		036623782E2065CD008FDE2E /* DiscoverPreviewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036623772E2065CD008FDE2E /* DiscoverPreviewData.swift */; };
@@ -344,6 +346,8 @@
 		0359A9792E02F17400818BD2 /* PreviewStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewStyle.swift; sourceTree = "<group>"; };
 		0359A97C2E03488000818BD2 /* CastViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CastViewModel.swift; sourceTree = "<group>"; };
 		035CB2BF2E51CA6500892271 /* AuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewModel.swift; sourceTree = "<group>"; };
+		03618C2E2E68DB1100D75D10 /* FirebaseAuthService+Deletion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FirebaseAuthService+Deletion.swift"; sourceTree = "<group>"; };
+		03618C302E68E79D00D75D10 /* AccountDangerZoneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountDangerZoneView.swift; sourceTree = "<group>"; };
 		03623F222E2D6E6E00066528 /* PreviewHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewHelpers.swift; sourceTree = "<group>"; };
 		03652CE42DFC56830031DCAD /* MovieDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetail.swift; sourceTree = "<group>"; };
 		036623772E2065CD008FDE2E /* DiscoverPreviewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverPreviewData.swift; sourceTree = "<group>"; };
@@ -1082,6 +1086,7 @@
 				0390F7E02E5DE79300E89B82 /* AuthPasswordField.swift */,
 				0390F7E22E5DE7AA00E89B82 /* AuthErrorBlock.swift */,
 				03DE96DF2E1BD818005D71A8 /* ValidationMessageView.swift */,
+				03618C302E68E79D00D75D10 /* AccountDangerZoneView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -1434,6 +1439,7 @@
 			isa = PBXGroup;
 			children = (
 				030289C92E52768B00F8AF00 /* FirebaseAuthService.swift */,
+				03618C2E2E68DB1100D75D10 /* FirebaseAuthService+Deletion.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1658,6 +1664,7 @@
 				0381F4D32DFA261400AC2ABB /* MovieGenresView.swift in Sources */,
 				03F3AD912E11C8D300B63AA2 /* DirectorView+Preview.swift in Sources */,
 				0313920B2E1B12960047ED6B /* ErrorMessageView.swift in Sources */,
+				03618C2F2E68DB1100D75D10 /* FirebaseAuthService+Deletion.swift in Sources */,
 				03E1BFED2E58E92B00737B4A /* AuthError.swift in Sources */,
 				033277EB2E15BD1A00E5A226 /* WatchProviderListView.swift in Sources */,
 				03BAD6972E297D130035F1F5 /* CastCarouselViewPreviewData.swift in Sources */,
@@ -1732,6 +1739,7 @@
 				03920A692E24F15B00804B06 /* SeeAllMoviesViewModel.swift in Sources */,
 				035CB2C02E51CA6500892271 /* AuthViewModel.swift in Sources */,
 				0390F7DF2E5DE78200E89B82 /* AuthEmailField.swift in Sources */,
+				03618C312E68E79D00D75D10 /* AccountDangerZoneView.swift in Sources */,
 				03DCB0642E5604890071C3B2 /* PreviewFactory+CreateAccount.swift in Sources */,
 				03BAD69D2E2984700035F1F5 /* PersonInfoPreviewData.swift in Sources */,
 				03FBBEB82E243B0B00E35462 /* SectionMoviesView+Previews.swift in Sources */,

--- a/CineMate/CineMate.xcodeproj/project.pbxproj
+++ b/CineMate/CineMate.xcodeproj/project.pbxproj
@@ -188,6 +188,7 @@
 		03D0734F2E60F605003EBED8 /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 03D0734E2E60F605003EBED8 /* GoogleSignInSwift */; };
 		03D5E2322E4C915100AAB2D3 /* FavoritePeopleGrid+Previews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D5E2312E4C915100AAB2D3 /* FavoritePeopleGrid+Previews.swift */; };
 		03D5E2362E4CCC0000AAB2D3 /* PersonCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D5E2352E4CCC0000AAB2D3 /* PersonCardView.swift */; };
+		03D6636E2E698CF800BBC0E8 /* FirebaseAuthService+ProviderInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D6636D2E698CF800BBC0E8 /* FirebaseAuthService+ProviderInfo.swift */; };
 		03D8D29C2E08836F006A117D /* CastMemberImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D8D29B2E08836E006A117D /* CastMemberImageView.swift */; };
 		03D8D29E2E088509006A117D /* PersonInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D8D29D2E088509006A117D /* PersonInfoView.swift */; };
 		03D8D2A02E088594006A117D /* PersonLinksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D8D29F2E088594006A117D /* PersonLinksView.swift */; };
@@ -430,6 +431,7 @@
 		03D073502E60FCFC003EBED8 /* GoogleService-Info.example.plist..plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.example.plist..plist"; sourceTree = "<group>"; };
 		03D5E2312E4C915100AAB2D3 /* FavoritePeopleGrid+Previews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FavoritePeopleGrid+Previews.swift"; sourceTree = "<group>"; };
 		03D5E2352E4CCC0000AAB2D3 /* PersonCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonCardView.swift; sourceTree = "<group>"; };
+		03D6636D2E698CF800BBC0E8 /* FirebaseAuthService+ProviderInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FirebaseAuthService+ProviderInfo.swift"; sourceTree = "<group>"; };
 		03D8D29B2E08836E006A117D /* CastMemberImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CastMemberImageView.swift; sourceTree = "<group>"; };
 		03D8D29D2E088509006A117D /* PersonInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonInfoView.swift; sourceTree = "<group>"; };
 		03D8D29F2E088594006A117D /* PersonLinksView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonLinksView.swift; sourceTree = "<group>"; };
@@ -1440,6 +1442,7 @@
 			children = (
 				030289C92E52768B00F8AF00 /* FirebaseAuthService.swift */,
 				03618C2E2E68DB1100D75D10 /* FirebaseAuthService+Deletion.swift */,
+				03D6636D2E698CF800BBC0E8 /* FirebaseAuthService+ProviderInfo.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1720,6 +1723,7 @@
 				0306124D2DF4C3DF0013F7AF /* MovieRepository.swift in Sources */,
 				035553102E2A4D51008064ED /* DirectorPreviewData.swift in Sources */,
 				03668ABB2DFBB01400132847 /* RelatedMovieCardView.swift in Sources */,
+				03D6636E2E698CF800BBC0E8 /* FirebaseAuthService+ProviderInfo.swift in Sources */,
 				03E5BE8B2E09FF4300D3C46B /* MovieRowDetails+Previews.swift in Sources */,
 				03BAD6992E297F5B0035F1F5 /* CastMemberPreviewData.swift in Sources */,
 				03D8D2B42E09F1FF006A117D /* MovieListView+Previews.swift in Sources */,

--- a/CineMate/CineMate/CineMateApp.swift
+++ b/CineMate/CineMate/CineMateApp.swift
@@ -16,8 +16,8 @@ import SwiftUI
 /// - Build shared services as `let` (e.g. `MovieRepository`, `FirebaseAuthService`)
 /// - Create and own long-lived view models as `@StateObject`
 /// - Switch UI:
-///   • **Signed out** -> `LoginView` flow
-///   • **Signed in**  -> `RootView` (tab bar)
+///   • **Signed out** --> `LoginView` flow
+///   • **Signed in**  --> `RootView` (tab bar)
 /// - Provide global environment objects: `AppNavigator`, `ToastCenter`
 /// - Handle Google sign-in callback via `.handleGoogleSignInURL()`
 ///
@@ -90,22 +90,11 @@ struct CineMate: App {
                         .navigationDestination(for: AppRoute.self) { route in
                             switch route {
                             case .createAccount:
-                                // Create Account inside the login flow
                                 CreateAccountView(
                                     createViewModel: CreateAccountViewModel(
                                         service: authService,
                                         onVerificationEmailSent: {
                                             toastCenter.show("Check your inbox to verify your email")
-                                            navigator.goBack()
-                                        },
-                                        onUpgraded: {
-                                            // If the user was anonymous -> now linked and signed in
-                                            if let uid = authService.currentUserID {
-                                                authViewModel.currentUID = uid
-                                                authViewModel.errorMessage = nil
-                                                authViewModel.isAuthenticating = false
-                                            }
-                                            toastCenter.show("Account created! You’re all set.")
                                             navigator.goBack()
                                         }
                                     )

--- a/CineMate/CineMate/Core/Firebase/Auth/Services/FirebaseAuthService+Deletion.swift
+++ b/CineMate/CineMate/Core/Firebase/Auth/Services/FirebaseAuthService+Deletion.swift
@@ -1,0 +1,126 @@
+//
+//  FirebaseAuthService+Deletion.swift
+//  CineMate
+//
+//  Created by Nicholas Samuelsson Jeria on 2025-09-03.
+//
+
+import Foundation
+import FirebaseAuth
+import FirebaseFirestore
+
+/// Deletion helpers for `FirebaseAuthService`.
+/// ------------------------------------------------
+/// What this extension does:
+/// - Deletes a user's **Firestore subtree** under `/users/{uid}`
+/// - Deletes the **Firebase Auth account**
+/// - Handles the **"requires recent login"** case (with a tolerant variant for anonymous users)
+///
+/// Requirements:
+/// - Firestore security rules must allow the signed-in user to read/write/delete
+///   their own `/users/{uid}` document and everything under it (see README).
+extension FirebaseAuthService {
+
+    // MARK: - Public API
+
+    /// Delete all Firestore data under `/users/{uid}` for the given user.
+    ///
+    /// Call this **before** deleting the Firebase Auth account.
+    ///
+    /// Notes:
+    /// - This removes known subcollections (e.g., `favorites`, `favorite_people`)
+    ///   and then deletes the user document itself.
+    /// - If you add new subcollections in the future, include them here.
+    ///
+    /// - Throws: `PreviewAuthError` in previews, or Firestore errors.
+    func deleteUserData(uid: String) async throws {
+        guard !ProcessInfo.processInfo.isPreview else { throw PreviewAuthError() }
+
+        // Clear known subcollections in small batches, then remove the user doc.
+        try await deleteAllDocuments(in: FirestorePaths.userFavorites(uid: uid))
+        try await deleteAllDocuments(in: FirestorePaths.userFavoritePeople(uid: uid))
+        try await FirestorePaths.userDoc(uid: uid).delete()
+    }
+
+    /// Delete the **currently signed-in** Firebase Auth account.
+    ///
+    /// - Throws: `PreviewAuthError` in previews, `AuthServiceError.noCurrentUser`
+    ///           when no user is signed in, or Firebase Auth errors.
+    func deleteAccount() async throws {
+        guard !ProcessInfo.processInfo.isPreview else { throw PreviewAuthError() }
+        guard let user = Auth.auth().currentUser else { throw AuthServiceError.noCurrentUser }
+        try await user.delete()
+    }
+
+    /// Delete the **currently signed-in** Firebase Auth account, but tolerate
+    /// the "requires recent login" error for **anonymous** users.
+    ///
+    /// Why:
+    /// - Anonymous sessions cannot be reauthenticated with a password, so we treat
+    ///   `AuthErrorCode.requiresRecentLogin` as a no-op success in that case.
+    ///
+    /// - Throws: `PreviewAuthError` in previews, `AuthServiceError.noCurrentUser`
+    ///           when no user is signed in, or rethrows other Firebase Auth errors.
+    func deleteAccountTolerantForAnonymous() async throws {
+        guard !ProcessInfo.processInfo.isPreview else { throw PreviewAuthError() }
+        guard let user = Auth.auth().currentUser else { throw AuthServiceError.noCurrentUser }
+        do {
+            try await user.delete()
+        } catch {
+            // If the user is anonymous and Firebase asks for a "recent login",
+            // there's nothing meaningful to reauthenticate with—treat as OK.
+            if user.isAnonymous && isRecentLoginRequired(error) {
+                return
+            }
+            throw error
+        }
+    }
+
+    /// Returns `true` when the error is `.requiresRecentLogin`.
+    func isRecentLoginRequired(_ error: Error) -> Bool {
+        let ns = error as NSError
+        return AuthErrorCode(rawValue: ns.code) == .requiresRecentLogin
+    }
+
+    // MARK: - Private
+
+    /// Delete **all** documents in a collection using small batches (paging).
+    ///
+    /// Why batches:
+    /// - Avoids hitting Firebase limits (max 500 writes per batch).
+    /// - Keeps memory and network usage steady.
+    ///
+    /// - Parameters:
+    ///   - collection: The collection to clear (e.g., `/users/{uid}/favorites`).
+    ///   - batchSize: Number of docs per page (≤ 500). Default is 200.
+    ///
+    /// - Throws: Firestore errors for query/commit failures or task cancellation.
+    fileprivate func deleteAllDocuments(in collection: CollectionReference, batchSize: Int = 200) async throws {
+        // Remember the last document of each page (for start-after pagination).
+        var lastSnapshot: QueryDocumentSnapshot?
+
+        while true {
+            // Fetch one page.
+            var query: Query = collection.limit(to: batchSize)
+            if let last = lastSnapshot {
+                query = query.start(afterDocument: last)
+            }
+
+            let snap = try await query.getDocuments()
+            guard !snap.documents.isEmpty else { break }
+
+            // Delete that page in a single batch.
+            let batch = collection.firestore.batch()
+            for doc in snap.documents {
+                batch.deleteDocument(doc.reference)
+            }
+            try await batch.commit()
+
+            // Move the window forward.
+            lastSnapshot = snap.documents.last
+
+            // Cooperatively exit if the surrounding Task was cancelled.
+            try Task.checkCancellation()
+        }
+    }
+}

--- a/CineMate/CineMate/Core/Firebase/Auth/Services/FirebaseAuthService+ProviderInfo.swift
+++ b/CineMate/CineMate/Core/Firebase/Auth/Services/FirebaseAuthService+ProviderInfo.swift
@@ -1,0 +1,56 @@
+//
+//  FirebaseAuthService+ProviderInfo.swift
+//  CineMate
+//
+//  Created by Nicholas Samuelsson Jeria on 2025-09-04.
+//
+
+import Foundation
+import FirebaseAuth
+
+/// FirebaseAuthService+ProviderInfo
+/// --------------------------------
+/// Adds a small helper to describe **how** the current user is signed in.
+/// Returns short, user-friendly labels like:
+/// - "Guest"
+/// - "Email (a@b.com)"
+/// - "Google (a@b.com)"
+/// - "Apple (a@b.com)"
+/// - "Other (a@b.com)"
+extension FirebaseAuthService {
+
+    /// Human-readable description of the current auth provider.
+    ///
+    /// Behavior:
+    /// - **Previews:** never touches Firebase --> returns "Preview user".
+    /// - **Signed out:** returns "Signed out".
+    /// - **Anonymous:** returns "Guest".
+    /// - **Provider-backed:** maps `providerID` to a label (google.com --> "Google",
+    ///   apple.com --> "Apple", password --> "Email"); falls back to "Other".
+    /// - If an email exists, it is appended as `" (email)"`.
+    var authProviderDescription: String {
+        // Skip SDK in previews
+        guard !ProcessInfo.processInfo.isPreview else {
+            return "Preview user"
+        }
+        guard let user = Auth.auth().currentUser else {
+            return "Signed out"
+        }
+        if user.isAnonymous { return "Guest" }
+
+        // Prefer explicit providers
+        let providers = user.providerData.map(\.providerID) // e.g. "google.com", "apple.com", "password"
+        let email = (user.email ?? "").trimmingCharacters(in: .whitespaces)
+
+        func label(_ name: String) -> String {
+            email.isEmpty ? name : "\(name) (\(email))"
+        }
+
+        if providers.contains("google.com") { return label("Google") }
+        if providers.contains("apple.com")  { return label("Apple") }
+        if providers.contains("password")   { return label("Email") }
+
+        // Fallback for any other provider
+        return label("Other")
+    }
+}

--- a/CineMate/CineMate/Core/Firebase/Auth/ViewModels/AuthViewModel.swift
+++ b/CineMate/CineMate/Core/Firebase/Auth/ViewModels/AuthViewModel.swift
@@ -10,37 +10,43 @@ import SwiftUI
 
 /// AuthViewModel
 /// -------------
-/// Small, preview-safe view model that holds **auth state** and exposes a few
-/// actions (guest sign-in, sign-out, delete account).
+/// Small, preview-safe view model that exposes auth **state** and a few actions
+/// (guest sign-in, sign-out, delete account).
 ///
 /// Goals:
 /// - **Simple DI:** Inject a `FirebaseAuthService` in production.
 /// - **Preview friendly:** Never touches SDKs in previews; uses static values.
-/// - **Tiny surface:** No `@EnvironmentObject` requirement; easy to test.
+/// - **Tiny surface:** No `@EnvironmentObject` required; easy to test.
 @MainActor
 final class AuthViewModel: ObservableObject {
 
     // MARK: - UI State (observable & writable)
-    /// Currently signed-in user id (or `nil` when signed out / preview).
+
+    /// Currently signed-in user **ID** (`nil` when signed out or in previews).
     @Published var currentUID: String?
-    /// `true` while an auth action runs (drives spinners / disables inputs).
+
+    /// `true` while an auth action runs (drive spinners / disable inputs).
     @Published var isAuthenticating = false
-    /// User-facing error text shown by the UI.
+
+    /// User-facing error text for overlays/toasts (nil = no error).
     @Published var errorMessage: String?
 
-    // MARK: - Dependencies (prod only)
+    // MARK: - Dependencies (production only)
+
     /// Real Firebase wrapper in production; `nil` in previews.
     private let service: FirebaseAuthService?
 
     // MARK: - Derived
-    /// `true` if the current Firebase user is anonymous.
+
+    /// `true` if the current Firebase user is **anonymous**.
     /// Always `false` in previews (we never boot the SDK there).
     var isGuest: Bool {
         if ProcessInfo.processInfo.isPreview { return false }
         return service?.isAnonymous ?? false
     }
 
-    // MARK: - Init (production)
+    // MARK: - Init (Production)
+
     /// Inject a real `FirebaseAuthService`. Seeds `currentUID` if not in previews.
     init(service: FirebaseAuthService) {
         self.service = service
@@ -49,10 +55,11 @@ final class AuthViewModel: ObservableObject {
         }
     }
 
-    // MARK: - Init (preview)
+    // MARK: - Init (Preview)
+
     /// Preview-only initializer (no SDK, no async, no delays).
     /// - Parameters:
-    ///   - simulatedUID: Pre-seeded UID (`nil` means “signed out”).
+    ///   - simulatedUID: Pre-seeded UID (`nil` means signed out).
     ///   - previewError: Optional error banner to show immediately.
     ///   - previewIsAuthenticating: Start in loading state if `true`.
     init(
@@ -68,9 +75,10 @@ final class AuthViewModel: ObservableObject {
 
     // MARK: - Actions
 
-    /// Ensure a signed-in user exists (anonymous if needed).
-    /// - **Preview:** Sets a static UID (unless an error is already shown).
-    /// - **Production:** Calls `service.isLoggedIn()`, with loading + error mapping.
+    /// Ensure a signed-in user exists (signs in **anonymously** if needed).
+    ///
+    /// - Preview: sets a static UID unless an error is already shown.
+    /// - Production: calls `service.isLoggedIn()` with loading + error mapping.
     func signInAsGuest() async {
         // Preview: static, deterministic behavior
         if ProcessInfo.processInfo.isPreview {
@@ -93,8 +101,9 @@ final class AuthViewModel: ObservableObject {
     }
 
     /// Sign out the current user.
-    /// - **Preview:** Resets local state only.
-    /// - **Production:** Delegates to `service.signOut()` and clears local state.
+    ///
+    /// - Preview: resets local state only.
+    /// - Production: delegates to `service.signOut()` and clears local state.
     func signOut() {
         // Preview: local reset
         if ProcessInfo.processInfo.isPreview {
@@ -125,17 +134,16 @@ extension AuthViewModel {
         case failure(String)
     }
 
-
-    /// Delete the **current user** (both Firestore data and the Firebase Auth account).
+    /// Delete the **current user** (Firestore data + Firebase Auth account).
     ///
     /// Flow:
-    /// 1. Delete `/users/{uid}` subtree in Firestore (known subcollections first, then user doc).
-    /// 2. Delete the Firebase Auth account.
-    /// 3. Clear local state (`currentUID`, `errorMessage`).
+    /// 1) Delete `/users/{uid}` subtree in Firestore (known subcollections first, then the user doc).
+    /// 2) Delete the Firebase Auth account (tolerates “recent login required” for anonymous users).
+    /// 3) Clear local state (`currentUID`, `errorMessage`).
     ///
     /// Returns:
-    /// - `.needsRecentLogin` when Firebase requires re-auth (non-anonymous users).
-    /// - `.success` if everything deleted (anonymous recent-login errors are tolerated).
+    /// - `.needsRecentLogin` when Firebase requires re-auth for **non-anonymous** users.
+    /// - `.success` when everything is removed (anonymous recent-login errors are tolerated).
     func deleteCurrentAccount() async -> DeleteAccountResult {
         if ProcessInfo.processInfo.isPreview { return .failure("Unavailable in previews") }
         guard let service = self.service, let uid = self.currentUID else {
@@ -147,9 +155,7 @@ extension AuthViewModel {
 
         do {
             try await service.deleteUserData(uid: uid)
-
             try await service.deleteAccountTolerantForAnonymous()
-
             try? service.signOut()
 
             await MainActor.run {
@@ -157,7 +163,6 @@ extension AuthViewModel {
                 self.errorMessage = nil
             }
             return .success
-
         } catch {
             if service.isRecentLoginRequired(error) && !(service.isAnonymous) {
                 return .needsRecentLogin
@@ -166,5 +171,18 @@ extension AuthViewModel {
             await MainActor.run { self.errorMessage = message }
             return .failure(message)
         }
+    }
+}
+
+// MARK: - Read-only auth info
+
+extension AuthViewModel {
+    /// Short, read-only description for Account screen:
+    /// “Google”, “Email”, “Guest”, or “Signed out” (previews: “Preview user”).
+    var authProviderDescription: String {
+        if ProcessInfo.processInfo.isPreview {
+            return currentUID == nil ? "Signed out" : "Preview user"
+        }
+        return service?.authProviderDescription ?? "Signed out"
     }
 }

--- a/CineMate/CineMate/Core/Firebase/Firestore/FirestorePaths.swift
+++ b/CineMate/CineMate/Core/Firebase/Firestore/FirestorePaths.swift
@@ -5,30 +5,40 @@
 //  Created by Nicholas Samuelsson Jeria on 2025-08-09.
 //
 
-import Foundation
 import FirebaseFirestore
 
-/// Central place for building Firestore paths.
-/// Keeps string literals out of call sites and ensures consistency.
+/// FirestorePaths
+/// --------------
+/// A small helper to build Firestore references in one place.
+/// Why?
+/// - Avoid hard-coded strings like "users" scattered in the codebase.
+/// - Keep paths consistent and easy to change later.
+/// - Return **references only** (no reads/writes here).
 enum FirestorePaths {
 
-    /// `/users/{uid}/favorites` – movie favorites of a user.
-    /// - Parameter uid: Firebase Auth user ID.
-    /// - Returns: Collection reference for the user's movie favorites.
-    static func userFavorites(uid: String) -> CollectionReference {
-        Firestore.firestore()
-            .collection("users")
-            .document(uid)
-            .collection("favorites")
+    /// The shared Firestore instance.
+    private static var db: Firestore { Firestore.firestore() }
+
+    /// `/users` collection.
+    static func users() -> CollectionReference {
+        db.collection("users")
     }
 
-    /// `/users/{uid}/favorite_people` – people favorites of a user.
-    /// - Parameter uid: Firebase Auth user ID.
-    /// - Returns: Collection reference for the user's people favorites.
+    /// `/users/{uid}` document.
+    /// - Parameter uid: The Firebase Auth user ID.
+    static func userDoc(uid: String) -> DocumentReference {
+        users().document(uid)
+    }
+
+    /// `/users/{uid}/favorites` collection.
+    /// - Parameter uid: The Firebase Auth user ID.
+    static func userFavorites(uid: String) -> CollectionReference {
+        userDoc(uid: uid).collection("favorites")
+    }
+
+    /// `/users/{uid}/favorite_people` collection.
+    /// - Parameter uid: The Firebase Auth user ID.
     static func userFavoritePeople(uid: String) -> CollectionReference {
-        Firestore.firestore()
-            .collection("users")
-            .document(uid)
-            .collection("favorite_people")
+        userDoc(uid: uid).collection("favorite_people")
     }
 }

--- a/CineMate/CineMate/Core/Navigation/RootView.swift
+++ b/CineMate/CineMate/Core/Navigation/RootView.swift
@@ -10,21 +10,20 @@ import SwiftUI
 /// RootView
 /// --------
 /// What this view does:
-/// • Hosts a single shared `NavigationStack` using `AppNavigator`.
-/// • Shows a `TabView` with five tabs: Movies, Favorites, Discover, Search, Account.
-/// • Handles navigation by pushing `AppRoute` values and resolving them in `navigationDestination`.
-/// • Shows lightweight, global toasts via `ToastCenter`.
+/// - Hosts one shared `NavigationStack` via `AppNavigator`.
+/// - Shows a `TabView` with five tabs: Movies, Favorites, Discover, Search, Account.
+/// - Resolves navigation by pushing `AppRoute` values in `.navigationDestination`.
+/// - Shows lightweight global toasts via `ToastCenter`.
 ///
 /// Guest gating:
-/// • If `authViewModel.isGuest` is true, **Discover** and **Search** are blocked.
-/// • We keep rendering those screens, but disable interaction and place
-///   a `LockedFeatureOverlay` on top.
-/// • The overlay’s CTA sends the user to the Create Account flow with `navigator.goToCreateAccount()`.
+/// - If `authViewModel.isGuest` is true, **Discover** and **Search** are locked.
+/// - We still render those screens but disable interaction and show a `LockedFeatureOverlay`.
+/// - The overlay’s CTA routes to Create Account via `navigator.goToCreateAccount()`.
 ///
 /// Design notes:
-/// • Simple DI: long-lived view models are injected from the App root.
-/// • View models do not perform navigation; routing is centralized here.
-/// • One place controls guest gating, so feature views stay clean.
+/// - Simple DI: long-lived view models are injected from the App root.
+/// - View models do not perform navigation; routing is centralized here.
+/// - One place controls guest gating so feature views stay clean.
 private enum MainTab: Hashable { case movies, favorites, discover, search, auth }
 
 struct RootView: View {
@@ -139,16 +138,12 @@ private extension RootView {
             )
 
         case .createAccount:
-            // In-app (user is already signed-in, possibly anonymous -> can be upgraded)
+            // In-app (user is signed in, possibly anonymous → can upgrade)
             CreateAccountView(
                 createViewModel: CreateAccountViewModel(
                     service: FirebaseAuthService(),
                     onVerificationEmailSent: {
                         toastCenter.show("Check your inbox to verify your email")
-                        navigator.goBack()
-                    },
-                    onUpgraded: {
-                        toastCenter.show("Account created! You’re all set.")
                         navigator.goBack()
                     }
                 )

--- a/CineMate/CineMate/Features/Account/Auth/Components/AccountDangerZoneView.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Components/AccountDangerZoneView.swift
@@ -1,0 +1,86 @@
+//
+//  AccountDangerZoneView.swift
+//  CineMate
+//
+//  Created by Nicholas Samuelsson Jeria on 2025-09-03.
+//
+
+import SwiftUI
+
+struct AccountDangerZoneView: View {
+    @ObservedObject var authViewModel: AuthViewModel
+    let onReauthenticationRequired: () -> Void
+    let onDeleteSuccess: () -> Void
+    let onDeleteFailure: (String) -> Void
+
+    @State private var isShowingDeleteAlert = false
+
+    var body: some View {
+        Section {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Danger Zone")
+                    .font(.headline)
+
+                Text("Delete your account and remove all data. This action cannot be undone")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+
+                Button(role: .destructive) {
+                    isShowingDeleteAlert = true
+                } label: {
+                    Text("Delete Account")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .disabled(authViewModel.isAuthenticating)
+                .alert("Delete account?", isPresented: $isShowingDeleteAlert) {
+                    Button("Delete", role: .destructive) {
+                        Task { await deleteAccount() }
+                    }
+                    Button("Cancel", role: .cancel) { }
+                } message: {
+                    Text("This will permanently remove your account and data")
+                }
+            }
+            .padding(.vertical, 4)
+        }
+    }
+
+    @MainActor
+    private func deleteAccount() async {
+        switch await authViewModel.deleteCurrentAccount() {
+        case .success:
+            onDeleteSuccess()
+        case .needsRecentLogin:
+            onReauthenticationRequired()
+        case .failure(let message):
+            onDeleteFailure(message)
+        }
+    }
+}
+
+#Preview("Default (static)") {
+    Form {
+        AccountDangerZoneView(
+            authViewModel: AuthViewModel(simulatedUID: "preview-uid"),
+            onReauthenticationRequired: {},
+            onDeleteSuccess: {},
+            onDeleteFailure: { _ in }
+        )
+    }
+}
+
+#Preview("Loading") {
+    Form {
+        AccountDangerZoneView(
+            authViewModel: AuthViewModel(
+                simulatedUID: "preview-uid",
+                previewError: nil,
+                previewIsAuthenticating: true
+            ),
+            onReauthenticationRequired: {},
+            onDeleteSuccess: {},
+            onDeleteFailure: { _ in }
+        )
+    }
+}

--- a/CineMate/CineMate/Features/Account/Auth/PreviewData/AccountView+Previews.swift
+++ b/CineMate/CineMate/Features/Account/Auth/PreviewData/AccountView+Previews.swift
@@ -12,21 +12,21 @@ import SwiftUI
 extension AccountView {
     /// Preview: user signed out.
     static var previewSignedOut: some View {
-        AccountView(viewModel: PreviewFactory.accountSignedOut())
+        AccountView(viewModel: PreviewFactory.accountSignedOut()).withPreviewToasts()
     }
 
     /// Preview: user signed in (shows short UID).
     static var previewSignedIn: some View {
-        AccountView(viewModel: PreviewFactory.accountSignedIn())
+        AccountView(viewModel: PreviewFactory.accountSignedIn()).withPreviewToasts()
     }
 
     /// Preview: error state (auth failure message).
     static var previewError: some View {
-        AccountView(viewModel: PreviewFactory.accountError())
+        AccountView(viewModel: PreviewFactory.accountError()).withPreviewToasts()
     }
 
     /// Preview: authenticating (inline loading UI).
     static var previewIsAuthenticating: some View {
-        AccountView(viewModel: PreviewFactory.accountIsAuthenticating())
+        AccountView(viewModel: PreviewFactory.accountIsAuthenticating()).withPreviewToasts()
     }
 }

--- a/CineMate/CineMate/Features/Account/Auth/ViewModels/CreateAccountViewModel.swift
+++ b/CineMate/CineMate/Features/Account/Auth/ViewModels/CreateAccountViewModel.swift
@@ -7,58 +7,42 @@
 
 import Foundation
 
-/// # CreateAccountViewModel
-/// Holds the **Create Account** form state, validates input, and calls the auth service.
+/// CreateAccountViewModel
+/// ----------------------
+/// Holds the **Create Account** form state, validates input, and talks to the auth service.
 ///
-/// How submit works:
-/// - If the current Firebase user is **anonymous** -> we **link/upgrade** the account (keeps the user signed in).
-/// - Otherwise -> we create a **new account**, **send a verification email**, and the service signs out.
-///
-/// Notes:
-/// - This type is `@MainActor` so all published changes are UI-safe.
-/// - Preview initializer never touches the network.
+/// Policy (simple & consistent):
+/// - For any email flow (new account or anonymous --> email link), we:
+///   1) send a **verification email**
+///   2) **sign out immediately**
+/// The user verifies via email and signs in again. No in-app “unverified” state.
 @MainActor
 final class CreateAccountViewModel: ObservableObject {
     // MARK: - Form state
-    /// User's email input.
     @Published var email: String = ""
-    /// User's password input.
     @Published var password: String = ""
-    /// Repeat password input.
     @Published var confirmPassword: String = ""
-    /// Must be true before submitting.
     @Published var acceptedTerms: Bool = false
 
     // MARK: - UI state
-    /// True while a submit is in progress.
     @Published var isAuthenticating: Bool = false
-    /// Set to true after the first submit attempt (enables helper texts).
     @Published var hasTriedSubmit: Bool = false
-    /// App-friendly error to show in the UI (nil = OK).
     @Published private(set) var appError: AuthAppError?
 
     // MARK: - Dependencies
-    /// Backend auth service (nil in previews).
     private let service: FirebaseAuthService?
-    /// Called after **verification email** is sent on normal sign-up.
     private let onVerificationEmailSent: () -> Void
-    /// Called after **anonymous -> email/password** upgrade succeeds.
-    private let onUpgraded: () -> Void
 
     // MARK: - Derived
-    /// Localized error text for the view.
     var errorMessage: String? { appError?.errorDescription }
-    /// Client-side checks.
     var isEmailValid: Bool { AuthValidator.isValidEmail(email) }
     var isPasswordValid: Bool { AuthValidator.isValidPassword(password) }
     var isPasswordMatch: Bool { !password.isEmpty && password == confirmPassword }
-
-    /// Button enablement.
     var canSubmit: Bool {
         isEmailValid && isPasswordValid && isPasswordMatch && acceptedTerms && !isAuthenticating
     }
 
-    // MARK: - Helper texts (shown after first submit or when useful)
+    // MARK: - Helper texts
     var emailHelperText: String? {
         hasTriedSubmit && !isEmailValid ? "Enter a valid email address" : nil
     }
@@ -77,15 +61,13 @@ final class CreateAccountViewModel: ObservableObject {
     // MARK: - Init
     init(
         service: FirebaseAuthService,
-        onVerificationEmailSent: @escaping () -> Void,
-        onUpgraded: @escaping () -> Void
+        onVerificationEmailSent: @escaping () -> Void
     ) {
         self.service = service
         self.onVerificationEmailSent = onVerificationEmailSent
-        self.onUpgraded = onUpgraded
     }
 
-    /// Preview-only init (no network, static state).
+    /// Preview-only initializer (no network, static state).
     init(
         previewEmail: String = "",
         previewIsAuthenticating: Bool = false,
@@ -93,7 +75,6 @@ final class CreateAccountViewModel: ObservableObject {
     ) {
         self.service = nil
         self.onVerificationEmailSent = {}
-        self.onUpgraded = {}
         self.email = previewEmail
         self.isAuthenticating = previewIsAuthenticating
         self.appError = previewErrorMessage.map { .unknown($0) }
@@ -102,12 +83,10 @@ final class CreateAccountViewModel: ObservableObject {
     // MARK: - Actions
 
     /// Submit the form.
-    /// Steps:
-    /// 1) Mark that we tried to submit and sanitize the email.
-    /// 2) If the form is valid, call the right auth flow:
-    ///    - `service.isAnonymous == true` -> link the anonymous user (upgrade).
-    ///    - else -> sign up, send verification email, and sign out (handled by the service).
-    /// 3) Map any backend error to `AuthAppError`.
+    ///
+    /// - If current user is **anonymous**: link to email/password,
+    ///   then **send verification email** and **sign out**.
+    /// - Else: create a new account, **send verification email**, then **sign out**.
     func submit() async {
         hasTriedSubmit = true
         email = AuthValidator.sanitizedEmail(from: email)
@@ -119,8 +98,10 @@ final class CreateAccountViewModel: ObservableObject {
         do {
             if service.isAnonymous {
                 _ = try await service.linkAnonymousAccount(email: email, password: password)
+                try await service.resendVerificationEmail()
+                try? service.signOut()
                 appError = nil
-                onUpgraded()
+                onVerificationEmailSent()
             } else {
                 try await service.signUpRequiringEmailVerification(email: email, password: password)
                 appError = nil

--- a/CineMate/CineMate/Features/Account/Auth/Views/AccountView.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Views/AccountView.swift
@@ -17,11 +17,9 @@ struct AccountView: View {
 
     var body: some View {
         ZStack {
-            Color.clear
-                .ignoresSafeArea()
-
             Form {
                 if let uid = authViewModel.currentUID {
+                    // Signed-in section
                     Section {
                         VStack(alignment: .leading, spacing: 8) {
                             Label("Account", systemImage: "person.crop.circle")
@@ -30,14 +28,24 @@ struct AccountView: View {
                             Text("Signed in as \(uid.prefix(6))")
                                 .foregroundStyle(.secondary)
 
-                            Button("Sign out") { authViewModel.signOut() }
-                                .buttonStyle(.borderedProminent)
-                                .disabled(authViewModel.isAuthenticating)
+                            HStack {
+                                Text("Sign-in method")
+                                Spacer()
+                                Text(authViewModel.authProviderDescription)
+                                    .foregroundStyle(.secondary)
+                                    .multilineTextAlignment(.trailing)
+                            }
+
+                            Button("Sign out") {
+                                authViewModel.signOut()
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .disabled(authViewModel.isAuthenticating)
                         }
                         .padding(.vertical, 4)
                     }
 
-                    // Danger Zone (delete)
+                    // Danger Zone (delete account)
                     AccountDangerZoneView(
                         authViewModel: authViewModel,
                         onReauthenticationRequired: {
@@ -56,14 +64,6 @@ struct AccountView: View {
             .navigationTitle("Account")
             .disabled(authViewModel.isAuthenticating)
 
-            // FULLSKÄRMS-LOADING (täcker allt vid radering/inloggning)
-            if authViewModel.isAuthenticating {
-                LoadingView(title: "Working…")
-                    .transition(.opacity)
-                    .zIndex(2)
-            }
-
-            // FULLSKÄRMS-FEL (täcker allt)
             if let error = authViewModel.errorMessage {
                 ErrorMessageView(
                     title: "Authentication Error",
@@ -71,10 +71,9 @@ struct AccountView: View {
                     onRetry: { authViewModel.errorMessage = nil }
                 )
                 .transition(.opacity)
-                .zIndex(3)
+                .zIndex(1)
             }
         }
-        .animation(.default, value: authViewModel.isAuthenticating)
         .animation(.default, value: authViewModel.errorMessage != nil)
     }
 }

--- a/CineMate/CineMate/Features/Account/Auth/Views/AccountView.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Views/AccountView.swift
@@ -8,42 +8,74 @@
 import SwiftUI
 
 struct AccountView: View {
-    @ObservedObject private var viewModel: AuthViewModel
+    @ObservedObject private var authViewModel: AuthViewModel
+    @EnvironmentObject private var toastCenter: ToastCenter
 
     init(viewModel: AuthViewModel) {
-        self._viewModel = ObservedObject(wrappedValue: viewModel)
+        self._authViewModel = ObservedObject(wrappedValue: viewModel)
     }
 
     var body: some View {
+        ZStack {
+            Color.clear
+                .ignoresSafeArea()
 
-        VStack(spacing: 12) {
-            Label("Account", systemImage: "person.crop.circle")
-                .font(.headline)
+            Form {
+                if let uid = authViewModel.currentUID {
+                    Section {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Label("Account", systemImage: "person.crop.circle")
+                                .font(.headline)
 
-            if let uid = viewModel.currentUID {
-                Text("Signed in as: \(uid.prefix(6))")
-                    .foregroundStyle(.secondary)
+                            Text("Signed in as \(uid.prefix(6))")
+                                .foregroundStyle(.secondary)
 
-                Button("Sign Out") {
-                    viewModel.signOut()
+                            Button("Sign out") { authViewModel.signOut() }
+                                .buttonStyle(.borderedProminent)
+                                .disabled(authViewModel.isAuthenticating)
+                        }
+                        .padding(.vertical, 4)
+                    }
+
+                    // Danger Zone (delete)
+                    AccountDangerZoneView(
+                        authViewModel: authViewModel,
+                        onReauthenticationRequired: {
+                            toastCenter.show("Please sign in again to delete your account")
+                            authViewModel.signOut()
+                        },
+                        onDeleteSuccess: {
+                            toastCenter.show("Account deleted successfully")
+                        },
+                        onDeleteFailure: { message in
+                            toastCenter.show(message)
+                        }
+                    )
                 }
-                .buttonStyle(.borderedProminent)
             }
-            contentStates
-        }
-    }
+            .navigationTitle("Account")
+            .disabled(authViewModel.isAuthenticating)
 
-    @ViewBuilder
-    private var contentStates: some View {
-        if let errorMessage = viewModel.errorMessage {
-            ErrorMessageView(
-                title: "Error signing in",
-                message: errorMessage
-            )
-        } else if viewModel.isAuthenticating {
-            LoadingView(title: "Signing in...")
+            // FULLSKÄRMS-LOADING (täcker allt vid radering/inloggning)
+            if authViewModel.isAuthenticating {
+                LoadingView(title: "Working…")
+                    .transition(.opacity)
+                    .zIndex(2)
+            }
+
+            // FULLSKÄRMS-FEL (täcker allt)
+            if let error = authViewModel.errorMessage {
+                ErrorMessageView(
+                    title: "Authentication Error",
+                    message: error,
+                    onRetry: { authViewModel.errorMessage = nil }
+                )
                 .transition(.opacity)
+                .zIndex(3)
+            }
         }
+        .animation(.default, value: authViewModel.isAuthenticating)
+        .animation(.default, value: authViewModel.errorMessage != nil)
     }
 }
 


### PR DESCRIPTION
### Why
Give users control to remove their data, make sign-in method clear for support, and avoid users getting stuck as “unverified”

### What
- Add **account deletion flow**
  - `FirebaseAuthService+Deletion`: `deleteUserData(uid)` (batched subcollection deletes) + `deleteAccountTolerantForAnonymous()` (ignore `requiresRecentLogin` for anonymous).
  - `FirestorePaths`: helpers for `/users/{uid}`, `/favorites`, `/favorite_people`
  - `AuthViewModel.deleteCurrentAccount()` with `DeleteAccountResult`
  - New **AccountDangerZoneView**: destructive button, confirm alert, loading overlay, disables input, callbacks for reauth/success/failure
  - **AccountView**: integrates Danger Zone, shows toast on outcomes

- Show **sign-in method**
  - `FirebaseAuthService+ProviderInfo.authProviderDescription`
  - `AuthViewModel.authProviderDescription`
  - **AccountView**: displays provider label (Google/Apple/Email/Guest [+ email])

- Simplify **email signup / anon→email**
  - `CreateAccountViewModel`: always **send verification email** then **sign out** (removes “upgrade & stay signed-in” path)
  - `RootView`: update `CreateAccountView` init,  remove `onUpgraded`

- Docs
  - README: update auth/account deletion, provider label, guest gating, and note Firestore rule to allow users to delete their own `/users/{uid}` subtree

### Notes
- Previews updated (`withPreviewToasts`, Danger Zone states)
- Requires publishing Firestore rule for user-owned deletes