### PR TITLE
Auth UI refresh + TermsSheet & signup fixes

### DIFF
--- a/CineMate/CineMate.xcodeproj/project.pbxproj
+++ b/CineMate/CineMate.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 		036E06B02E5B9B45006BBA92 /* ResetPasswordPreviewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036E06AF2E5B9B45006BBA92 /* ResetPasswordPreviewData.swift */; };
 		036E06B22E5B9BAB006BBA92 /* PreviewFactory+ResetPassword.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036E06B12E5B9BAB006BBA92 /* PreviewFactory+ResetPassword.swift */; };
 		036E06B42E5BA418006BBA92 /* ResetPasswordSheet+Previews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036E06B32E5BA418006BBA92 /* ResetPasswordSheet+Previews.swift */; };
+		0371433A2E7200F200A35E04 /* TermSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 037143392E7200F200A35E04 /* TermSheet.swift */; };
 		03757F132E60F2A800C5C2C1 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03757F122E60F2A800C5C2C1 /* GoogleService-Info.plist */; };
 		0381F4D32DFA261400AC2ABB /* MovieGenresView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0381F4D22DFA261400AC2ABB /* MovieGenresView.swift */; };
 		0384BD6D2E11318D00790AA5 /* PersonLinksView+Previews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0384BD6C2E11318D00790AA5 /* PersonLinksView+Previews.swift */; };
@@ -375,6 +376,7 @@
 		036E06AF2E5B9B45006BBA92 /* ResetPasswordPreviewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetPasswordPreviewData.swift; sourceTree = "<group>"; };
 		036E06B12E5B9BAB006BBA92 /* PreviewFactory+ResetPassword.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PreviewFactory+ResetPassword.swift"; sourceTree = "<group>"; };
 		036E06B32E5BA418006BBA92 /* ResetPasswordSheet+Previews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ResetPasswordSheet+Previews.swift"; sourceTree = "<group>"; };
+		037143392E7200F200A35E04 /* TermSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermSheet.swift; sourceTree = "<group>"; };
 		03757F122E60F2A800C5C2C1 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		0381F4D22DFA261400AC2ABB /* MovieGenresView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieGenresView.swift; sourceTree = "<group>"; };
 		0384BD6C2E11318D00790AA5 /* PersonLinksView+Previews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersonLinksView+Previews.swift"; sourceTree = "<group>"; };
@@ -608,6 +610,7 @@
 		030612612DF4CD3F0013F7AF /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				037143382E7200E900A35E04 /* Sheets */,
 				036CB2FB2E64C7AC0031FB34 /* Overlay */,
 				03F0A4C42E5A46000071856D /* FormControls */,
 				039AF9AE2E2599BD00B90527 /* Poster */,
@@ -1022,6 +1025,14 @@
 				036CB2FC2E64C7BA0031FB34 /* LockedFeatureOverlay.swift */,
 			);
 			path = Overlay;
+			sourceTree = "<group>";
+		};
+		037143382E7200E900A35E04 /* Sheets */ = {
+			isa = PBXGroup;
+			children = (
+				037143392E7200F200A35E04 /* TermSheet.swift */,
+			);
+			path = Sheets;
 			sourceTree = "<group>";
 		};
 		03757F142E60F2DA00C5C2C1 /* Google */ = {
@@ -1750,6 +1761,7 @@
 				03E5BE8B2E09FF4300D3C46B /* MovieRowDetails+Previews.swift in Sources */,
 				03BAD6992E297F5B0035F1F5 /* CastMemberPreviewData.swift in Sources */,
 				03D8D2B42E09F1FF006A117D /* MovieListView+Previews.swift in Sources */,
+				0371433A2E7200F200A35E04 /* TermSheet.swift in Sources */,
 				033CAA0A2E6251D6009514D0 /* GoogleSignInBootstrap.swift in Sources */,
 				03E3557E2DF9C060001F1001 /* MovieCredits.swift in Sources */,
 				031F2E362E0DDFDE001E41B8 /* TMDBImageHelper.swift in Sources */,

--- a/CineMate/CineMate.xcodeproj/project.pbxproj
+++ b/CineMate/CineMate.xcodeproj/project.pbxproj
@@ -224,6 +224,10 @@
 		03EE7E672E2AD26E00674B84 /* MovieCreditsPreviewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EE7E662E2AD26E00674B84 /* MovieCreditsPreviewData.swift */; };
 		03EE7E692E2AD5CC00674B84 /* MovieDetailPreviewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EE7E682E2AD5CC00674B84 /* MovieDetailPreviewData.swift */; };
 		03EE7E6B2E2AD7EF00674B84 /* PersonPreviewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EE7E6A2E2AD7EF00674B84 /* PersonPreviewData.swift */; };
+		03F013392E71ADB200F240BA /* AuthTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F013382E71ADB200F240BA /* AuthTheme.swift */; };
+		03F0133B2E71ADE800F240BA /* PillWhiteButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F0133A2E71ADE800F240BA /* PillWhiteButtonStyle.swift */; };
+		03F0133D2E71AE0700F240BA /* OrDivider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F0133C2E71AE0700F240BA /* OrDivider.swift */; };
+		03F0133F2E71AE4100F240BA /* AuthHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F0133E2E71AE4100F240BA /* AuthHeader.swift */; };
 		03F0A4BE2E5A42160071856D /* TrailingIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F0A4BD2E5A42160071856D /* TrailingIcon.swift */; };
 		03F0A4C02E5A42750071856D /* RoundedField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F0A4BF2E5A42750071856D /* RoundedField.swift */; };
 		03F3AD8D2E11C1FA00B63AA2 /* ShareLinkButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F3AD8C2E11C1FA00B63AA2 /* ShareLinkButtonView.swift */; };
@@ -467,6 +471,10 @@
 		03EE7E662E2AD26E00674B84 /* MovieCreditsPreviewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieCreditsPreviewData.swift; sourceTree = "<group>"; };
 		03EE7E682E2AD5CC00674B84 /* MovieDetailPreviewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetailPreviewData.swift; sourceTree = "<group>"; };
 		03EE7E6A2E2AD7EF00674B84 /* PersonPreviewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonPreviewData.swift; sourceTree = "<group>"; };
+		03F013382E71ADB200F240BA /* AuthTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthTheme.swift; sourceTree = "<group>"; };
+		03F0133A2E71ADE800F240BA /* PillWhiteButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PillWhiteButtonStyle.swift; sourceTree = "<group>"; };
+		03F0133C2E71AE0700F240BA /* OrDivider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrDivider.swift; sourceTree = "<group>"; };
+		03F0133E2E71AE4100F240BA /* AuthHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthHeader.swift; sourceTree = "<group>"; };
 		03F0A4BD2E5A42160071856D /* TrailingIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrailingIcon.swift; sourceTree = "<group>"; };
 		03F0A4BF2E5A42750071856D /* RoundedField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedField.swift; sourceTree = "<group>"; };
 		03F3AD8C2E11C1FA00B63AA2 /* ShareLinkButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareLinkButtonView.swift; sourceTree = "<group>"; };
@@ -537,6 +545,7 @@
 			children = (
 				036A61AC2E00130500DB7BF0 /* Core */,
 				03A620C02DF774CA00C075E8 /* Features */,
+				034EAB9A2E69A25B00932E10 /* Design */,
 				030612252DF4BEB40013F7AF /* CineMateApp.swift */,
 				030E469D2DFDA7DD00285FE7 /* Secrets.example.plist */,
 				03D073502E60FCFC003EBED8 /* GoogleService-Info.example.plist..plist */,
@@ -915,6 +924,17 @@
 				033277F82E15C4EC00E5A226 /* WatchProviderCategoryButton+Previews.swift */,
 			);
 			path = Components;
+			sourceTree = "<group>";
+		};
+		034EAB9A2E69A25B00932E10 /* Design */ = {
+			isa = PBXGroup;
+			children = (
+				03F013382E71ADB200F240BA /* AuthTheme.swift */,
+				03F0133A2E71ADE800F240BA /* PillWhiteButtonStyle.swift */,
+				03F0133C2E71AE0700F240BA /* OrDivider.swift */,
+				03F0133E2E71AE4100F240BA /* AuthHeader.swift */,
+			);
+			path = Design;
 			sourceTree = "<group>";
 		};
 		035553112E2A4DD6008064ED /* Director */ = {
@@ -1618,6 +1638,7 @@
 				030599842E1F0C5000626215 /* SortOption.swift in Sources */,
 				03E090D52E25A17800ECBF5F /* GenreChipView.swift in Sources */,
 				034014FB2E31781200089026 /* MovieGenresView+Previews.swift in Sources */,
+				03F013392E71ADB200F240BA /* AuthTheme.swift in Sources */,
 				033277F72E15C42900E5A226 /* WatchProviderCategoryButton.swift in Sources */,
 				03FC25DF2E06A4D400AACB5E /* CastViewModel+Preview.swift in Sources */,
 				031392072E1B11CA0047ED6B /* SearchBarView.swift in Sources */,
@@ -1627,6 +1648,7 @@
 				03D8D2AA2E09DFA8006A117D /* MovieDetailInfoView+Previews.swift in Sources */,
 				0355ABD02E1082D3002E6F77 /* PersonExternalIDs.swift in Sources */,
 				0368AF922DF5BB3C009B1F56 /* MovieRowDetails.swift in Sources */,
+				03F0133B2E71ADE800F240BA /* PillWhiteButtonStyle.swift in Sources */,
 				03920A6B2E24F70300804B06 /* PreviewFactory+SeeAllMovies.swift in Sources */,
 				03B76F452E4B441B0007840A /* FavoritePeopleViewModel.swift in Sources */,
 				03CE4A422E0F214F00D70F70 /* PersonMetaInfoView.swift in Sources */,
@@ -1722,6 +1744,7 @@
 				03CC7E242E22F3070045E678 /* DiscoverHorrorPreviewData.swift in Sources */,
 				0306124D2DF4C3DF0013F7AF /* MovieRepository.swift in Sources */,
 				035553102E2A4D51008064ED /* DirectorPreviewData.swift in Sources */,
+				03F0133F2E71AE4100F240BA /* AuthHeader.swift in Sources */,
 				03668ABB2DFBB01400132847 /* RelatedMovieCardView.swift in Sources */,
 				03D6636E2E698CF800BBC0E8 /* FirebaseAuthService+ProviderInfo.swift in Sources */,
 				03E5BE8B2E09FF4300D3C46B /* MovieRowDetails+Previews.swift in Sources */,
@@ -1775,6 +1798,7 @@
 				0368AFC12DF61333009B1F56 /* MovieCategory.swift in Sources */,
 				034531B22E4A9215003A44AC /* PersonRef.swift in Sources */,
 				0319D5692E47D09200A906B9 /* FirestorePaths.swift in Sources */,
+				03F0133D2E71AE0700F240BA /* OrDivider.swift in Sources */,
 				030612472DF4C05C0013F7AF /* SecretManager.swift in Sources */,
 				03E090DD2E25A2F600ECBF5F /* GenreSelectorView+Previews.swift in Sources */,
 				0390F7E32E5DE7AA00E89B82 /* AuthErrorBlock.swift in Sources */,

--- a/CineMate/CineMate/CineMateApp.swift
+++ b/CineMate/CineMate/CineMateApp.swift
@@ -104,6 +104,7 @@ struct CineMate: App {
                             }
                         }
                     }
+                    .toast(toastCenter.message)
                 } else {
                     // MAIN APP
                     RootView(

--- a/CineMate/CineMate/Core/Firebase/Auth/Validation/TermsContent.swift
+++ b/CineMate/CineMate/Core/Firebase/Auth/Validation/TermsContent.swift
@@ -10,35 +10,36 @@ import Foundation
 enum TermsContent {
     /// Short markdown for the “View terms” sheet.
     static let termsMarkdown = """
-    # Terms of Service
-    **Last updated:** 2025-08-21  
+    **Last updated:** 2025-09-10
 
     ## About
     CineMate uses Firebase Auth for sign-in and TMDB for artwork/metadata.  
-    > Uses the TMDB API but not endorsed by TMDB.
+    > Uses the TMDB API but is not endorsed or certified by TMDB.
 
     ## Eligibility
-    Must be 13+ (or local minimum).
+    You must be 13+ (or the local minimum).
 
     ## Account
-    Keep your login secure and follow the law.
+    Keep your credentials secure and follow applicable laws.
 
     ## Data & Privacy
-    We store minimal data (email, ID, favorites).  
-    Passwords handled by Firebase. HTTPS used.  
-    Contact: **support@example.com**
+    We store minimal data (email, user ID, favorites).  
+    Passwords are handled by Firebase. All requests use HTTPS.
 
     ## TMDB Content
-    Posters/metadata may change.  
-    See [TMDB Terms](https://www.themoviedb.org/terms-of-use).
+    Posters and metadata may change.  
+    See the [TMDB Terms](https://www.themoviedb.org/terms-of-use).
 
     ## Acceptable Use
-    No scraping, abuse, or IP violation.
+    No scraping, abuse, or IP infringement.
 
     ## Warranty
-    Provided “as is.” No liability for losses.
+    Provided “as is,” without warranties. We are not liable for losses.
 
     ## Updates
-    Using the app means you accept changes.
+    Using the app means you accept changes to these terms.
+
+    ## Support
+    **Contact:** Open a GitHub Issue on the project repository.
     """
 }

--- a/CineMate/CineMate/Core/Navigation/RootView.swift
+++ b/CineMate/CineMate/Core/Navigation/RootView.swift
@@ -167,16 +167,3 @@ extension CastMember {
         self.init(id: crew.id, name: crew.name, character: nil, profilePath: crew.profilePath)
     }
 }
-
-/*
-- Extract reusable UI:
-  - Design/AuthTheme (color tokens)
-  - Design/PillWhiteButtonStyle (white capsule button)
-  - Design/AuthHeader (icon + title + subtitle)
-  - Design/OrDivider (+ DividerLine)
-- Update LoginView:
-  - Replace card with flat layout,  gradient background
-  - Move guest sign-in under Google,  equal 48pt buttons
-  - Use new components,  drop inline helpers
-  - a11y: hide decorative header icon
- */

--- a/CineMate/CineMate/Core/Navigation/RootView.swift
+++ b/CineMate/CineMate/Core/Navigation/RootView.swift
@@ -101,7 +101,6 @@ struct RootView: View {
                 destination(for: debugRoute(route))
             }
         }
-        // Global toast layer
         .toast(toastCenter.message)
     }
 }
@@ -168,3 +167,16 @@ extension CastMember {
         self.init(id: crew.id, name: crew.name, character: nil, profilePath: crew.profilePath)
     }
 }
+
+/*
+- Extract reusable UI:
+  - Design/AuthTheme (color tokens)
+  - Design/PillWhiteButtonStyle (white capsule button)
+  - Design/AuthHeader (icon + title + subtitle)
+  - Design/OrDivider (+ DividerLine)
+- Update LoginView:
+  - Replace card with flat layout,  gradient background
+  - Move guest sign-in under Google,  equal 48pt buttons
+  - Use new components,  drop inline helpers
+  - a11y: hide decorative header icon
+ */

--- a/CineMate/CineMate/Design/AuthHeader.swift
+++ b/CineMate/CineMate/Design/AuthHeader.swift
@@ -1,0 +1,39 @@
+//
+//  AuthHeader.swift
+//  CineMate
+//
+//  Created by Nicholas Samuelsson Jeria on 2025-09-10.
+//
+
+import SwiftUI
+
+/// Small, reusable header for auth screens (icon + title + subtitle).
+/// Visual-only, strings are not localized here. Uses `AuthTheme` colors.
+struct AuthHeader: View {
+    var body: some View {
+        VStack(spacing: 10) {
+            ZStack {
+                Circle()
+                    .fill(.ultraThinMaterial)
+                    .frame(width: 72, height: 72)
+                    .overlay(Circle().strokeBorder(AuthTheme.cardStroke))
+                Image(systemName: "film.fill")
+                    .font(.system(size: 28, weight: .bold))
+                    .symbolRenderingMode(.hierarchical)
+                    .foregroundStyle(AuthTheme.iconOnCurtain)
+            }
+            .accessibilityHidden(true)
+            
+            Text("CineMate")
+                .font(.title2).bold()
+                .foregroundStyle(.white)
+            
+            Text("Sign in to continue")
+                .font(.subheadline)
+                .foregroundStyle(.white.opacity(0.9))
+        }
+        .padding(.top, 4)
+    }
+}
+
+#Preview { AuthHeader() }

--- a/CineMate/CineMate/Design/AuthTheme.swift
+++ b/CineMate/CineMate/Design/AuthTheme.swift
@@ -1,0 +1,19 @@
+//
+//  AuthTheme.swift
+//  CineMate
+//
+//  Created by Nicholas Samuelsson Jeria on 2025-09-10.
+//
+
+import SwiftUI
+
+/// Auth-specific color tokens (cinema “curtain” + “popcorn” accent).
+/// Scope to auth screens,  if reused broadly, promote to app-wide design tokens.
+enum AuthTheme {
+    static let curtainTop    = Color(red: 0.10, green: 0.02, blue: 0.05) // #1A000D
+    static let curtainBottom = Color(red: 0.24, green: 0.05, blue: 0.07) // #3D0C12
+    static let popcorn       = Color(red: 0.96, green: 0.77, blue: 0.09) // #F5C518
+
+    static let cardStroke    = Color.white.opacity(0.12)
+    static let iconOnCurtain = Color.white.opacity(0.95)
+}

--- a/CineMate/CineMate/Design/OrDivider.swift
+++ b/CineMate/CineMate/Design/OrDivider.swift
@@ -1,0 +1,42 @@
+//
+//  OrDivider.swift
+//  CineMate
+//
+//  Created by Nicholas Samuelsson Jeria on 2025-09-10.
+//
+
+import SwiftUI
+
+/// A horizontal separator with a centered label, e.g. "OR CONTINUE WITH".
+/// Pass a localized `text`. The visual is uppercase.
+struct OrDivider: View {
+    let text: LocalizedStringKey
+    var lineColor: Color = .white
+    var lineOpacity: CGFloat = 0.35
+
+    var body: some View {
+        HStack(spacing: 12) {
+            DividerLine(color: lineColor.opacity(lineOpacity))
+            Text(text)
+                .textCase(.uppercase) // visual only
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.white.opacity(0.8))
+            DividerLine(color: lineColor.opacity(lineOpacity))
+        }
+        .padding(.vertical, 4)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+/// Thin separator line used by `OrDivider`.
+private struct DividerLine: View {
+    var color: Color
+    var body: some View {
+        Rectangle()
+            .fill(color)
+            .frame(height: 1)
+            .frame(maxWidth: .infinity)
+            .cornerRadius(1)
+            .accessibilityHidden(true)
+    }
+}

--- a/CineMate/CineMate/Design/PillWhiteButtonStyle.swift
+++ b/CineMate/CineMate/Design/PillWhiteButtonStyle.swift
@@ -1,0 +1,29 @@
+//
+//  PillWhiteButtonStyle.swift
+//  CineMate
+//
+//  Created by Nicholas Samuelsson Jeria on 2025-09-10.
+//
+
+import SwiftUI
+
+/// White capsule button style for primary actions on dark/colored backgrounds.
+/// Adds subtle press feedback (scale + shadow). Avoid on light surfaces for contrast.
+struct PillWhiteButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .padding(.vertical, 14)
+            .background(Capsule().fill(Color.white))
+            .overlay(Capsule().strokeBorder(Color.white.opacity(0.7)))
+            .foregroundStyle(AuthTheme.popcorn)
+            .shadow(color: .black.opacity(configuration.isPressed ? 0.05 : 0.12),
+                    radius: configuration.isPressed ? 6 : 12,
+                    y: configuration.isPressed ? 2 : 6)
+            .scaleEffect(configuration.isPressed ? 0.98 : 1)
+    }
+}
+
+/// Convenience: `Button("…").buttonStyle(.pillWhite)`
+extension ButtonStyle where Self == PillWhiteButtonStyle {
+    static var pillWhite: PillWhiteButtonStyle { .init() }
+}

--- a/CineMate/CineMate/Features/Account/Auth/Views/CreateAccountView.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Views/CreateAccountView.swift
@@ -21,97 +21,126 @@ struct CreateAccountView: View {
 
     var body: some View {
         ZStack {
-            VStack(spacing: 16) {
-                // Email
-                AuthEmailField(
-                    text: $createViewModel.email,
-                    isDisabled: createViewModel.isAuthenticating,
-                    submitLabel: .next,
-                    onSubmit: {
-                        emailFocused = false
-                        passwordFocused = true
-                    },
-                    isFocused: $emailFocused
-                )
-                if let text = createViewModel.emailHelperText {
-                    ValidationMessageView(message: text)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
+            LinearGradient(
+                colors: [AuthTheme.curtainTop, AuthTheme.curtainBottom],
+                startPoint: .top, endPoint: .bottom
+            )
+            .ignoresSafeArea()
 
-                // Password
-                AuthPasswordField(
-                    title: "Password",
-                    text: $createViewModel.password,
-                    isDisabled: createViewModel.isAuthenticating,
-                    mode: .create,
-                    submitLabel: .next,
-                    onSubmit: {
-                        passwordFocused = false
-                        confirmFocused = true
-                    },
-                    isFocused: $passwordFocused
-                )
-                if let text = createViewModel.passwordHelperText {
-                    ValidationMessageView(message: text)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
+            VStack(spacing: 22) {
+                AuthHeader()
 
-                // Confirm password
-                AuthPasswordField(
-                    title: "Confirm Password",
-                    text: $createViewModel.confirmPassword,
-                    isDisabled: createViewModel.isAuthenticating,
-                    mode: .create,
-                    submitLabel: .done,
-                    onSubmit: { Task { await createViewModel.submit() } },
-                    isFocused: $confirmFocused
-                )
-                if let text = createViewModel.confirmHelperText {
-                    ValidationMessageView(message: text)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
+                VStack(alignment: .leading, spacing: 16) {
+                    // Email
+                    AuthEmailField(
+                        text: $createViewModel.email,
+                        isDisabled: createViewModel.isAuthenticating,
+                        submitLabel: .next,
+                        onSubmit: {
+                            emailFocused = false
+                            passwordFocused = true
+                        },
+                        isFocused: $emailFocused
+                    )
+                    if let text = createViewModel.emailHelperText {
+                        ValidationMessageView(message: text)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
 
-                // Terms
-                Toggle("I accept the terms and conditions",
-                       isOn: $createViewModel.acceptedTerms)
-                .disabled(createViewModel.isAuthenticating)
+                    // Password
+                    AuthPasswordField(
+                        title: "Password",
+                        text: $createViewModel.password,
+                        isDisabled: createViewModel.isAuthenticating,
+                        mode: .create,
+                        submitLabel: .next,
+                        onSubmit: {
+                            passwordFocused = false
+                            confirmFocused = true
+                        },
+                        isFocused: $passwordFocused
+                    )
+                    if let text = createViewModel.passwordHelperText {
+                        ValidationMessageView(message: text)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
 
-                Button("View terms") { showTerms = true }
-                    .buttonStyle(.plain)
-                    .font(.footnote)
+                    // Confirm password
+                    AuthPasswordField(
+                        title: "Confirm Password",
+                        text: $createViewModel.confirmPassword,
+                        isDisabled: createViewModel.isAuthenticating,
+                        mode: .create,
+                        submitLabel: .done,
+                        onSubmit: { Task { await createViewModel.submit() } },
+                        isFocused: $confirmFocused
+                    )
+                    if let text = createViewModel.confirmHelperText {
+                        ValidationMessageView(message: text)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
 
-                if let text = createViewModel.termsHelperText {
-                    ValidationMessageView(message: text)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("I accept the terms and conditions")
+                            .font(.callout.weight(.semibold))
+                            .foregroundStyle(AuthTheme.popcorn)
+                            .frame(maxWidth: .infinity, alignment: .center)
+                            .padding(.trailing, 56)
+                            .overlay(alignment: .trailing) {
+                                Toggle("", isOn: $createViewModel.acceptedTerms)
+                                    .labelsHidden()
+                                    .tint(AuthTheme.popcorn)
+                                    .disabled(createViewModel.isAuthenticating)
+                            }
 
-                // Submit (smart)
-                Button("Create Account") { Task { await createViewModel.submit() } }
-                    .buttonStyle(.borderedProminent)
+                        Button("View terms") {
+                            showTerms = true
+                        }
+                        .buttonStyle(.plain)
+                        .font(.footnote.weight(.semibold))
+                        .foregroundStyle(AuthTheme.popcorn)
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                    }
+
+                    if let text = createViewModel.termsHelperText {
+                        ValidationMessageView(message: text)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+
+                    // Submit (smart)
+                    Button {
+                        Task { await createViewModel.submit() }
+                    } label: {
+                        Text("Create Account")
+                            .fontWeight(.semibold)
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.pillWhite)
+                    .controlSize(.large)
+                    .frame(height: 48)
                     .disabled(!createViewModel.canSubmit)
 
-                // Server error
-                if let message = createViewModel.errorMessage {
-                    ValidationMessageView(message: message)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                    // Server error
+                    if let message = createViewModel.errorMessage {
+                        ValidationMessageView(message: message)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
                 }
-            }
-            .padding()
+                .padding(.horizontal, 20)
 
+                Spacer(minLength: 8)
+            }
+            .padding(.bottom, 16)
+
+            // Loading overlay
             if createViewModel.isAuthenticating {
                 LoadingView(title: "Creating account…")
                     .transition(.opacity)
-                    .ignoresSafeArea()
             }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-        .allowsHitTesting(!createViewModel.isAuthenticating)
+        .tint(AuthTheme.popcorn)
         .sheet(isPresented: $showTerms) {
-            ScrollView {
-                Text(TermsContent.termsMarkdown)
-                    .padding()
-                    .textSelection(.enabled)
-            }
+            TermsSheet(markdown: TermsContent.termsMarkdown)
         }
         .task {
             try? await Task.sleep(nanoseconds: 120_000_000)

--- a/CineMate/CineMate/Features/Account/Auth/Views/ResetPasswordSheet.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Views/ResetPasswordSheet.swift
@@ -31,41 +31,81 @@ struct ResetPasswordSheet: View {
 
     // MARK: - Body
     var body: some View {
-        VStack(spacing: 16) {
-            Text("Reset password")
-                .font(.title3).bold()
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-            AuthEmailField(
-                text: $viewModel.email,
-                isDisabled: viewModel.isSending,
-                submitLabel: .send,
-                onSubmit: { Task { await handleSend() } },
-                isFocused: $emailFocused
+        ZStack {
+            LinearGradient(
+                colors: [AuthTheme.curtainTop, AuthTheme.curtainBottom],
+                startPoint: .top, endPoint: .bottom
             )
+            .ignoresSafeArea()
 
-            if let helper = viewModel.emailHelperText {
-                ValidationMessageView(message: helper)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+            VStack(spacing: 22) {
+                VStack(spacing: 10) {
+                    ZStack {
+                        Circle()
+                            .fill(.ultraThinMaterial)
+                            .frame(width: 64, height: 64)
+                            .overlay(Circle().strokeBorder(AuthTheme.cardStroke))
+
+                        Image(systemName: "lock.rotation")
+                            .font(.system(size: 24, weight: .semibold))
+                            .symbolRenderingMode(.hierarchical)
+                            .foregroundStyle(AuthTheme.iconOnCurtain)
+                    }
+
+                    Text("Reset password")
+                        .font(.title3.bold())
+                        .foregroundStyle(.white)
+
+                    Text("Enter your email to get a reset link")
+                        .font(.subheadline)
+                        .foregroundStyle(.white.opacity(0.9))
+                }
+                .padding(.top, 15)
+
+                VStack(alignment: .leading, spacing: 16) {
+                    AuthEmailField(
+                        text: $viewModel.email,
+                        isDisabled: viewModel.isSending,
+                        submitLabel: .send,
+                        onSubmit: { Task { await handleSend() } },
+                        isFocused: $emailFocused
+                    )
+
+                    if let helper = viewModel.emailHelperText {
+                        ValidationMessageView(message: helper)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    if let errorText = viewModel.appError?.errorDescription {
+                        ValidationMessageView(message: errorText)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+
+                    Button {
+                        Task { await handleSend() }
+                    } label: {
+                        Text("Send reset link")
+                            .frame(maxWidth: .infinity)
+                            .fontWeight(.semibold)
+                    }
+                    .buttonStyle(.pillWhite)
+                    .controlSize(.large)
+                    .frame(height: 48)
+                    .disabled(viewModel.isSending)
+
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.white.opacity(0.85))
+                    .frame(maxWidth: .infinity, alignment: .center)
+                }
+                .padding(.horizontal, 20)
+
+                Spacer(minLength: 8)
             }
-            if let errorText = viewModel.appError?.errorDescription {
-                ValidationMessageView(message: errorText)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            }
-
-            Button { Task { await handleSend() } } label: {
-                Text("Send reset link").frame(maxWidth: .infinity)
-            }
-            .buttonStyle(.borderedProminent)
-            .disabled(viewModel.isSending)
-
-            Button("Cancel") { dismiss() }
-                .buttonStyle(.plain)
-                .foregroundStyle(.secondary)
-
-            Spacer()
+            .padding(.bottom, 16)
         }
-        .padding()
+        .tint(AuthTheme.popcorn)
         .presentationDetents([.large])
         .presentationDragIndicator(.visible)
         .task {

--- a/CineMate/CineMate/Features/Resources/Assets.xcassets/Color.colorset/Contents.json
+++ b/CineMate/CineMate/Features/Resources/Assets.xcassets/Color.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xA6",
+          "green" : "0xB8",
+          "red" : "0x14"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x88",
+          "green" : "0x94",
+          "red" : "0x0D"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/CineMate/CineMate/Features/UI/Components/Sheets/TermSheet.swift
+++ b/CineMate/CineMate/Features/UI/Components/Sheets/TermSheet.swift
@@ -1,0 +1,91 @@
+//
+//  TermSheet.swift
+//  CineMate
+//
+//  Created by Nicholas Samuelsson Jeria on 2025-09-10.
+//
+
+import SwiftUI
+
+struct TermsSheet: View {
+    let markdown: String
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        ZStack {
+            LinearGradient(colors: [AuthTheme.curtainTop, AuthTheme.curtainBottom],
+                           startPoint: .top, endPoint: .bottom)
+            .ignoresSafeArea()
+
+            VStack(spacing: 22) {
+                TermsHeader()
+
+                ScrollView {
+                    Text(markdownAttributed)
+                        .lineSpacing(6)
+                        .foregroundStyle(.white.opacity(0.92))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(20)
+                        .background(
+                            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                                .fill(.ultraThinMaterial)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                                        .stroke(AuthTheme.cardStroke)
+                                )
+                        )
+                        .shadow(color: .black.opacity(0.12), radius: 10, y: 4)
+                        .padding(.horizontal, 20)
+                }
+                .scrollIndicators(.never)
+
+                Button {
+                    dismiss()
+                } label: {
+                    Text("Close").fontWeight(.semibold).frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.pillWhite)
+                .frame(height: 48)
+                .padding(.horizontal, 20)
+            }
+            .padding(.bottom, 16)
+        }
+        .tint(AuthTheme.popcorn)
+        .presentationDetents([.large])
+        .presentationDragIndicator(.visible)
+    }
+
+    // MARK: - Helper
+    private var markdownAttributed: AttributedString {
+        (try? AttributedString(markdown: markdown)) ?? AttributedString(markdown)
+    }
+}
+
+private struct TermsHeader: View {
+    var body: some View {
+        VStack(spacing: 10) {
+            ZStack {
+                Circle()
+                    .fill(.ultraThinMaterial)
+                    .frame(width: 64, height: 64)
+                    .overlay(Circle().strokeBorder(AuthTheme.cardStroke))
+                Image(systemName: "doc.text")
+                    .font(.system(size: 24, weight: .semibold))
+                    .symbolRenderingMode(.hierarchical)
+                    .foregroundStyle(AuthTheme.iconOnCurtain)
+            }
+            Text("Terms of Service")
+                .font(.title3.bold())
+                .foregroundStyle(.white)
+            
+            Text("Please review before creating an account")
+                .font(.subheadline)
+                .foregroundStyle(.white.opacity(0.9))
+        }
+        .padding(.top, 15)
+    }
+}
+
+#Preview {
+    TermsSheet(markdown: TermsContent.termsMarkdown)
+}

--- a/README.md
+++ b/README.md
@@ -12,18 +12,25 @@ It emphasizes clean architecture, fast UI iteration (Previews + mocks), and safe
 
 ## Feature Demos
 
-> **Watch CineMate in Action** — [Full demo on Vimeo »](https://vimeo.com/1110514808)
+> **Watch CineMate in Action** — [Watch the CineMate demo on Vimeo »](https://vimeo.com/1117585898)
 
-| Browse -> Detail | Real-time Favorites | Search + Infinite Scroll |
+<details>
+<summary><strong>Show GIFs (3)</strong></summary>
+
+<br/>
+
+| Browse → Detail | Real-time Favorites | Search + Infinite Scroll |
 |---|---|---|
 | <img src="Assets/popular_to_detail.gif" width="260" alt="Browse list to movie detail" /> | <img src="Assets/favorites_realtime.gif" width="260" alt="Toggle favorites with real-time updates" /> | <img src="Assets/search_infinite_scroll.gif" width="260" alt="Search with infinite scroll" /> |
+
+</details>
 
 ---
 
 ## Features
 
 ### Movies
-- Browse popular/top‑rated movies; details include credits & recommendations
+- Browse popular/top‑rated movies, details include credits & recommendations
 - Search with debounce + infinite scroll
 - Save/remove favorites for **movies** and **people** with real‑time updates
 - Region‑specific watch providers
@@ -31,7 +38,7 @@ It emphasizes clean architecture, fast UI iteration (Previews + mocks), and safe
 ### Authentication (Firebase)
 - **Create Account (Email/Password)** — sends **verification email** on signup and then **signs out**. Users verify via email and sign in again. No “unverified” in‑app state.
 - **Sign In (Email/Password)**
-- **Anonymous (Guest)** — one‑tap. Anonymous users can later **link** to email/password during sign‑up; we still **send verification** and **sign out** afterward (same policy as above).
+- **Anonymous (Guest)** — one‑tap. Anonymous users can later **link** to email/password during sign‑up, we still **send verification** and **sign out** afterward (same policy as above).
 - **Google Sign‑In** — official Google SwiftUI button + Firebase credential exchange
 - **Sign Out** — from Account tab
 
@@ -45,7 +52,7 @@ It emphasizes clean architecture, fast UI iteration (Previews + mocks), and safe
 - Shows short **UID** preview.
 - **Sign Out** button.
 - **Danger Zone**: delete account + data. Includes inline loading overlay while deleting.
-- Full‑screen **Error overlay** (`ErrorMessageView`) for auth errors; ephemeral **toasts** for transient events (e.g. delete failure/success).
+- Full‑screen **Error overlay** (`ErrorMessageView`) for auth errors, ephemeral **toasts** for transient events (e.g. delete failure/success).
 
 > Deleting account removes `/users/{uid}` data in Firestore first, then deletes the Firebase Auth user. For anonymous users, “requires recent login” is tolerated so deletion still succeeds. Deleting a Firebase user **does not** delete your external Google/Apple account.
 
@@ -57,7 +64,7 @@ It emphasizes clean architecture, fast UI iteration (Previews + mocks), and safe
 - `View+Focus.applyFocus(_:)`
 
 **Validation & errors**
-- `AuthValidator` — trims/sanitizes email; password policy (min/max length, requires lower/upper/digit)
+- `AuthValidator` — trims/sanitizes email, password policy (min/max length, requires lower/upper/digit)
 - `AuthAppError` — maps Firebase/Google errors -> compact, user‑friendly messages
 
 ---
@@ -89,14 +96,14 @@ You need the following local configuration files before running the app:
 Allow each authenticated user to manage their own `/users/{uid}` subtree, including deletes of documents and subcollections:
 
 ```js
-rules_version = '2';
+rules_version = '2',
 
 service cloud.firestore {
 match /databases/{database}/documents {
 
 // Owner-only access to the entire /users/{uid} subtree
 match /users/{uid}/{document=**} {
-allow read, write: if request.auth != null && request.auth.uid == uid;
+allow read, write: if request.auth != null && request.auth.uid == uid,
 }
 }
 }
@@ -130,7 +137,7 @@ GoogleSignInBootstrap.ensureConfigured()
 1. Open project in **Xcode 15.3** or later  
 2. Add `Secrets.plist` (see template in `Resources/Secrets/Secrets.example.plist`)  
 3. Add `GoogleService-Info.plist` to the app target  
-4. In **Firebase Console**: enable Anonymous, Email/Password, Google; enable Firestore; publish rules  
+4. In **Firebase Console**: enable Anonymous, Email/Password, Google enable Firestore, publish rules  
 5. Select iOS **17.4+** device/simulator and run (**Cmd+R**)
 
 ---
@@ -162,7 +169,7 @@ GoogleSignInBootstrap.ensureConfigured()
 1. Delete Firestore data under `/users/{uid}` (subcollections first)  
 2. Delete Firebase Auth user (`deleteAccountTolerantForAnonymous()` handles anon recent‑login)  
 3. `signOut()` and clear local state
-- UI: `AccountDangerZoneView` shows inline `LoadingView`; success/failure signaled via `ToastCenter`.
+- UI: `AccountDangerZoneView` shows inline `LoadingView`, success/failure signaled via `ToastCenter`.
 - External identity (Google/Apple) is **not** deleted — only the Firebase user and Firestore data for this app.
 
 ---
@@ -254,6 +261,32 @@ CineMate/
 
 I’m seeking a **LIA (internship)**. Open to remote/hybrid — based in **Stockholm (Haninge)**.  
 **LinkedIn:** https://www.linkedin.com/in/nicholas-samuelsson-jeria-69778391
+
+---
+
+## Legal & Attribution
+
+- This product uses the TMDB API but is **not endorsed or certified by TMDB**.
+- Streaming availability data is provided by **JustWatch**.
+- Movie posters, backdrops, and logos are © their respective owners and are shown via TMDB, they are not included in this repository’s license and must not be redistributed.
+
+**Links**
+- TMDB: https://www.themoviedb.org  • Terms: https://www.themoviedb.org/terms-of-use  • API: https://developer.themoviedb.org/
+- JustWatch: https://www.justwatch.com/
+
+**In-app attribution**
+- Display “Powered by TMDB” (with the TMDB logo/link) somewhere visible in the app (e.g., About/Settings or on detail screens).
+- When showing “Where to watch”, also display “Data provided by JustWatch” with a link to justwatch.com.
+
+**License note**
+- The application code is licensed as per this repo’s LICENSE. Third-party trademarks and media (TMDB/JustWatch assets, posters, logos) are excluded from the code license.
+
+---
+
+## Project Status
+
+CineMate is stable and usable today. Development continues **part-time** while I focus on new courses, so updates may be irregular.  
+If you hit an issue or want to propose an improvement, please **open a GitHub Issue**—I’ll respond as time allows.
 
 ---
 


### PR DESCRIPTION
# Auth UI refresh, TermsSheet, signup flow fixes

**Why**
Unify auth screens, reduce duplication, and make the email-verification flow clear.

**Changes**
- Extract shared UI: `AuthTheme`, `AuthHeader`, `PillWhiteButtonStyle`, `OrDivider`
- Redesign **Login** (gradient, 48pt buttons, shared comps)
- Add **TermsSheet** + “View terms” in Create Account (TMDB notice, GitHub Issues contact)
- Fix **Create Account** enablement,  on submit: send verification -> sign out -> back to Login with toast
- Style **Reset Password** to match theme
- Update README + `TermsContent`
- Wire routes/toast in `RootView` / `CineMateApp`

**Notes**
Updates may be slower (studies).