### PR TITLE
refactor(previews): harden preview environment and remove duplicate

### DIFF
--- a/CineMate/CineMate/Core/Models/Discover/DiscoverFilter.swift
+++ b/CineMate/CineMate/Core/Models/Discover/DiscoverFilter.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-/// A filter model for building query parameters used with TMDB's `/discover/movie` endpoint.
+/// Filter values for TMDB discover requests.
 struct DiscoverFilter: Equatable, Hashable {
     var sortOption: SortOption = .popularityDesc
     var withGenres: [Int] = []
@@ -20,17 +20,17 @@ struct DiscoverFilter: Equatable, Hashable {
     var includeAdult: Bool = false
     var page: Int = 1
 
-    /// Builds an array of URLQueryItems to be used in network requests to TMDB.
+    /// Query items for the discover request.
     var queryItems: [URLQueryItem] {
         buildQueryItems()
     }
 
-    /// Builds query items and appends extra items (for endpoint-specific additions).
+    /// Returns the base query items plus extra items.
     func queryItems(adding additionalItems: [URLQueryItem]) -> [URLQueryItem] {
-        buildQueryItems() + sanitize(additionalItems)
+        buildQueryItems() + additionalItems.sanitizedForRequest()
     }
 
-    /// Returns a copy of this filter updated with the provided page.
+    /// Returns a copy with a safe page number.
     func withPage(_ page: Int) -> DiscoverFilter {
         var updated = self
         updated.page = max(1, page)
@@ -78,23 +78,7 @@ private extension DiscoverFilter {
         }
 
         items.append(.init(name: DiscoverQueryKey.page, value: "\(page)"))
-
-        return sanitize(items)
-    }
-
-    func sanitize(_ items: [URLQueryItem]) -> [URLQueryItem] {
-        items.compactMap { item in
-            let name = item.name.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !name.isEmpty else { return nil }
-
-            guard let rawValue = item.value else {
-                return URLQueryItem(name: name, value: nil)
-            }
-
-            let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !value.isEmpty else { return nil }
-            return URLQueryItem(name: name, value: value)
-        }
+        return items.sanitizedForRequest()
     }
 }
 

--- a/CineMate/CineMate/Core/Networking/TMDBEndpoint.swift
+++ b/CineMate/CineMate/Core/Networking/TMDBEndpoint.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-/// Enum containing all TMDB endpoints used in the app.
+/// TMDB endpoints used by the app.
 enum TMDBEndpoint {
     case movieDetail(Int)
     case popular
@@ -25,7 +25,7 @@ enum TMDBEndpoint {
     case discover
     case nowPlaying
     case movieGenres
-
+    
     var path: String {
         switch self {
         case .movieDetail(let id): return "/movie/\(id)"
@@ -46,28 +46,28 @@ enum TMDBEndpoint {
         case .movieGenres: return "/genre/movie/list"
         }
     }
-
+    
     func url(baseURL: URL, queryItems: [URLQueryItem] = []) throws -> URL {
         guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
             throw TMDBError.badURL
         }
-
+        
         let normalizedBasePath = components.path.hasSuffix("/")
-            ? String(components.path.dropLast())
-            : components.path
+        ? String(components.path.dropLast())
+        : components.path
         components.path = normalizedBasePath + path
-
-        let cleanedQueryItems = sanitize(queryItems: queryItems)
+        
+        let cleanedQueryItems = queryItems.sanitizedForRequest()
         if !cleanedQueryItems.isEmpty {
             components.queryItems = cleanedQueryItems
         }
-
+        
         guard let url = components.url else {
             throw TMDBError.badURL
         }
         return url
     }
-
+    
     func makeRequest(
         baseURL: URL,
         queryItems: [URLQueryItem] = [],
@@ -82,16 +82,17 @@ enum TMDBEndpoint {
     }
 }
 
-private extension TMDBEndpoint {
-    func sanitize(queryItems: [URLQueryItem]) -> [URLQueryItem] {
-        queryItems.compactMap { item in
+extension Array where Element == URLQueryItem {
+    /// Returns query items with trimmed names and values.
+    func sanitizedForRequest() -> [URLQueryItem] {
+        compactMap { item in
             let name = item.name.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !name.isEmpty else { return nil }
-
+            
             guard let rawValue = item.value else {
                 return URLQueryItem(name: name, value: nil)
             }
-
+            
             let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !value.isEmpty else { return nil }
             return URLQueryItem(name: name, value: value)

--- a/CineMate/CineMate/Features/Account/Auth/PreviewData/AccountView+Previews.swift
+++ b/CineMate/CineMate/Features/Account/Auth/PreviewData/AccountView+Previews.swift
@@ -7,26 +7,25 @@
 
 import SwiftUI
 
-/// **AccountView+Previews**
-/// Convenience, named previews for common Account states.
+/// Preview states for `AccountView`.
 extension AccountView {
-    /// Preview: user signed out.
+    /// Signed out state.
     static var previewSignedOut: some View {
-        AccountView(viewModel: PreviewFactory.accountSignedOut()).withPreviewToasts()
+        AccountView(viewModel: PreviewFactory.accountSignedOut()).withPreviewEnvironment()
     }
 
-    /// Preview: user signed in (shows short UID).
+    /// Signed in state.
     static var previewSignedIn: some View {
-        AccountView(viewModel: PreviewFactory.accountSignedIn()).withPreviewToasts()
+        AccountView(viewModel: PreviewFactory.accountSignedIn()).withPreviewEnvironment()
     }
 
-    /// Preview: error state (auth failure message).
+    /// Error state.
     static var previewError: some View {
-        AccountView(viewModel: PreviewFactory.accountError()).withPreviewToasts()
+        AccountView(viewModel: PreviewFactory.accountError()).withPreviewEnvironment()
     }
 
-    /// Preview: authenticating (inline loading UI).
+    /// Loading state.
     static var previewIsAuthenticating: some View {
-        AccountView(viewModel: PreviewFactory.accountIsAuthenticating()).withPreviewToasts()
+        AccountView(viewModel: PreviewFactory.accountIsAuthenticating()).withPreviewEnvironment()
     }
 }

--- a/CineMate/CineMate/Features/Account/Auth/Views/LoginView.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Views/LoginView.swift
@@ -8,20 +8,20 @@
 import SwiftUI
 import GoogleSignInSwift
 
-/// Login screen for email password, Google, and guest sign in.
+/// Sign in screen for email, Google, and guest access.
 struct LoginView: View {
     @ObservedObject private var viewModel: LoginViewModel
     @EnvironmentObject private var toastCenter: ToastCenter
     @Environment(\.colorScheme) private var colorScheme
     private let onRegister: () -> Void
-
+    
     @State private var showResetSheet = false
     @FocusState private var emailFocused: Bool
     @FocusState private var passwordFocused: Bool
     private let authProviderButtonSize: CGFloat = 48
     private let authProviderCornerRadius: CGFloat = 12
     private let contentMaxWidth: CGFloat = 380
-
+    
     init(
         viewModel: LoginViewModel,
         onRegister: @escaping () -> Void = {}
@@ -29,20 +29,22 @@ struct LoginView: View {
         _viewModel = .init(wrappedValue: viewModel)
         self.onRegister = onRegister
     }
-
+    
     var body: some View {
         ZStack {
             LinearGradient(colors: [AuthTheme.curtainTop, AuthTheme.curtainBottom],
                            startPoint: .top, endPoint: .bottom)
             .ignoresSafeArea()
             AuthTheme.curtainContrastOverlay.ignoresSafeArea()
-
+            
             ScrollView(showsIndicators: false) {
                 VStack(spacing: 24) {
                     loginHeader
                         .padding(.top, 12)
-
-                    VStack(alignment: .leading, spacing: 16) {
+                    
+                    Spacer()
+                    
+                    VStack(alignment: .leading, spacing: 24) {
                         AuthEmailField(
                             text: $viewModel.email,
                             isDisabled: viewModel.isAuthenticating,
@@ -54,7 +56,7 @@ struct LoginView: View {
                             ValidationMessageView(message: hint, palette: .curtain)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                         }
-
+                        
                         AuthPasswordField(
                             text: $viewModel.password,
                             isDisabled: viewModel.isAuthenticating,
@@ -67,14 +69,14 @@ struct LoginView: View {
                             ValidationMessageView(message: hint, palette: .curtain)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                         }
-
+                        
                         Button("Forgot password?") { showResetSheet = true }
                             .buttonStyle(.plain)
                             .font(.footnote.weight(.semibold))
                             .foregroundStyle(AuthTheme.linkOnCurtain)
                             .frame(maxWidth: .infinity, alignment: .trailing)
                             .disabled(viewModel.isAuthenticating)
-
+                        
                         Button { Task { await viewModel.login() } } label: {
                             Text("Sign in").fontWeight(.semibold).frame(maxWidth: .infinity)
                         }
@@ -82,7 +84,7 @@ struct LoginView: View {
                         .controlSize(.large)
                         .frame(height: 48)
                         .disabled(viewModel.isAuthenticating)
-
+                        
                         if let message = viewModel.errorMessage {
                             AuthErrorBlock(
                                 message: message,
@@ -97,9 +99,9 @@ struct LoginView: View {
                                 }
                             }
                         }
-
+                        
                         OrDivider(text: "or continue with")
-
+                        
                         HStack(spacing: 16) {
                             GoogleSignInButton(
                                 scheme: colorScheme == .dark ? .dark : .light,
@@ -115,7 +117,7 @@ struct LoginView: View {
                                 )
                                 .shadow(color: .black.opacity(0.06), radius: 6, y: 2)
                                 .accessibilityLabel("Sign in with Google")
-
+                            
                             Button {
                                 Task { await viewModel.continueAsGuest() }
                             } label: {
@@ -145,7 +147,7 @@ struct LoginView: View {
                             .accessibilityLabel("Continue as guest")
                         }
                         .frame(maxWidth: .infinity)
-
+                        
                         Text("Use Google for your account, or continue as guest without signing up.")
                             .font(.caption)
                             .foregroundStyle(AuthTheme.textOnCurtainSecondary)
@@ -155,10 +157,7 @@ struct LoginView: View {
                     }
                     .frame(maxWidth: contentMaxWidth)
                     .padding(.horizontal, 20)
-
-                    registerPrompt
-                        .frame(maxWidth: contentMaxWidth)
-                        .padding(.horizontal, 20)
+                    
                 }
                 .frame(maxWidth: .infinity)
                 .padding(.top, 16)
@@ -184,8 +183,15 @@ struct LoginView: View {
             viewModel.clearError()
         }
         .tint(AuthTheme.popcorn)
+        .safeAreaInset(edge: .bottom) {
+            registerPrompt
+                .frame(maxWidth: contentMaxWidth)
+                .padding(.horizontal, 20)
+                .padding(.top, 8)
+                .padding(.bottom, 10)
+        }
     }
-
+    
     @ViewBuilder
     private var loginHeader: some View {
 #if DEBUG
@@ -194,7 +200,7 @@ struct LoginView: View {
         AuthHeader()
 #endif
     }
-
+    
     private var registerPrompt: some View {
         HStack(spacing: 6) {
             Text("Don’t have an account?")
@@ -209,7 +215,7 @@ struct LoginView: View {
         .font(.footnote)
         .frame(maxWidth: .infinity)
     }
-
+    
 #if DEBUG
     private func applyDebugCredentials() {
         guard let email = DebugLoginCredentials.email,
@@ -238,10 +244,10 @@ struct LoginView: View {
 #if DEBUG
 private enum DebugLoginCredentials {
     private static let environment = ProcessInfo.processInfo.environment
-
+    
     static var email: String? { sanitize(environment["DEBUG_LOGIN_EMAIL"]) }
     static var password: String? { sanitize(environment["DEBUG_LOGIN_PASSWORD"]) }
-
+    
     private static func sanitize(_ value: String?) -> String? {
         guard let value else { return nil }
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/CineMate/CineMate/Features/People/Components/KnownFor/KnownForScrollView+Previews.swift
+++ b/CineMate/CineMate/Features/People/Components/KnownFor/KnownForScrollView+Previews.swift
@@ -8,9 +8,9 @@
 import SwiftUI
 
 private extension MovieViewModel {
-    /// Preview instance seeded with stubs from person’s known-for credits.
+    /// Preview model with cached movie stubs.
     static var previewWithStubs: MovieViewModel {
-        let vm = MovieViewModel()
+        let vm = MovieViewModel(repository: PreviewFactory.repository)
         for credit in PersonPreviewData.movieCredits {
             if let stub = credit.asMovie {
                 vm.cacheStub(stub)
@@ -31,7 +31,7 @@ extension KnownForScrollView {
         .background(Color(.systemBackground))
         .withPreviewNavigation()
     }
-
+    
     static var previewEmpty: some View {
         KnownForScrollView(
             movies: [],
@@ -41,7 +41,7 @@ extension KnownForScrollView {
         .background(Color(.systemBackground))
         .withPreviewNavigation()
     }
-
+    
     static var previewPartial: some View {
         let partial = [
             PersonMovieCredit(
@@ -62,7 +62,7 @@ extension KnownForScrollView {
         .background(Color(.systemBackground))
         .withPreviewNavigation()
     }
-
+    
     static var previewOverflow: some View {
         let manyMovies = (1...25).map { index in
             PersonMovieCredit(

--- a/CineMate/CineMate/Features/People/Components/PersonMovieCard/PersonMovieCardView+Previews.swift
+++ b/CineMate/CineMate/Features/People/Components/PersonMovieCard/PersonMovieCardView+Previews.swift
@@ -8,9 +8,9 @@
 import SwiftUI
 
 private extension MovieViewModel {
-    /// Preview instance seeded with a single stub from the given credit.
+    /// Preview model with one cached movie stub.
     static func previewWithStub(from credit: PersonMovieCredit) -> MovieViewModel {
-        let vm = MovieViewModel()
+        let vm = MovieViewModel(repository: PreviewFactory.repository)
         if let stub = credit.asMovie {
             vm.cacheStub(stub)
         }
@@ -19,40 +19,40 @@ private extension MovieViewModel {
 }
 
 extension PersonMovieCardView {
-    /// Preview with a full movie credit and stub injection so navigation detail has something immediately.
+    /// Full preview state.
     static var preview: some View {
         let movieCredit = PersonMovieCardPreviewData.standard
         let movieVM = MovieViewModel.previewWithStub(from: movieCredit)
-
+        
         return PersonMovieCardView(movie: movieCredit, movieViewModel: movieVM)
             .padding()
             .background(Color(.systemBackground))
             .withPreviewNavigation()
     }
-
-    /// Preview where posterPath is missing (fallback image shown).
+    
+    /// Missing poster state.
     static var previewMissingPoster: some View {
         let movieCredit = PersonMovieCardPreviewData.missingPoster
         let movieVM = MovieViewModel.previewWithStub(from: movieCredit)
-
+        
         return PersonMovieCardView(movie: movieCredit, movieViewModel: movieVM)
             .padding()
             .background(Color(.systemBackground))
             .withPreviewNavigation()
     }
-
-    /// Preview where title is nil (fallback "Untitled" shown).
+    
+    /// Missing title state.
     static var previewMissingTitle: some View {
         let movieCredit = PersonMovieCardPreviewData.missingTitle
         let movieVM = MovieViewModel.previewWithStub(from: movieCredit)
-
+        
         return PersonMovieCardView(movie: movieCredit, movieViewModel: movieVM)
             .padding()
             .background(Color(.systemBackground))
             .withPreviewNavigation()
     }
-
-    /// Variant without providing a MovieViewModel (no stub injection).
+    
+    /// Preview without a movie stub.
     static var previewWithoutStub: some View {
         PersonMovieCardView(movie: PersonMovieCardPreviewData.standard, movieViewModel: nil)
             .padding()

--- a/CineMate/CineMate/Features/Previews/Data/PreviewHelpers.swift
+++ b/CineMate/CineMate/Features/Previews/Data/PreviewHelpers.swift
@@ -7,30 +7,134 @@
 
 import SwiftUI
 
-/**
- PreviewHelpers
- --------------
- `withPreviewNavigation()`
- A one-liner for previews that need an `AppNavigator`.
-
- • Creates an isolated navigator (`AppNavigator()`)
- • Wraps the view in a `NavigationStack` so swipe-back works
- • Injects the navigator with `.environmentObject(nav)`
-
- Use it whenever the previewed view (or a child) expects
- `@EnvironmentObject var navigator: AppNavigator`.
- */
+/// Preview helpers for shared environment setup.
 extension View {
-    /// Wraps `self` in a `NavigationStack` and injects a fresh navigator.
-    func withPreviewNavigation() -> some View {
-        let nav = AppNavigator()          // 1. isolated GPS
-        return NavigationStack { self }   // 2. optional stack for gestures
-            .environmentObject(nav)       // 3. inject into the environment
+    /// Injects the shared preview environment.
+    @MainActor
+    func withPreviewEnvironment() -> some View {
+        withPreviewEnvironment(
+            navigator: AppNavigator(),
+            toastCenter: ToastCenter()
+        )
     }
 
-    /// Injects a fresh `ToastCenter` for preview use.
+    /// Injects a provided preview environment.
+    @MainActor
+    func withPreviewEnvironment(
+        navigator: AppNavigator,
+        toastCenter: ToastCenter
+    ) -> some View {
+        self
+            .environmentObject(navigator)
+            .environmentObject(toastCenter)
+    }
+
+    /// Wraps the view in preview navigation.
+    @MainActor
+    func withPreviewNavigation() -> some View {
+        PreviewNavigationHost(content: self)
+    }
+
+    /// Injects the preview environment without navigation.
+    @MainActor
     func withPreviewToasts() -> some View {
-        let toast = ToastCenter()
-        return self.environmentObject(toast)
+        withPreviewEnvironment()
+    }
+}
+
+@MainActor
+private struct PreviewNavigationHost<Content: View>: View {
+    let content: Content
+
+    @StateObject private var navigator = AppNavigator()
+    @StateObject private var toastCenter = ToastCenter()
+
+    var body: some View {
+        NavigationStack(path: $navigator.path) {
+            content
+                .navigationDestination(for: AppRoute.self) { route in
+                    PreviewNavigationDestination(route: route)
+                }
+        }
+        .withPreviewEnvironment(navigator: navigator, toastCenter: toastCenter)
+    }
+}
+
+@MainActor
+private struct PreviewNavigationDestination: View {
+    let route: AppRoute
+
+    var body: some View {
+        switch route {
+        case .movie(let id):
+            movieDestination(for: id)
+        case .person(let id):
+            personDestination(for: id)
+        case .genre(let id, let name):
+            GenreDetailView(
+                genreId: id,
+                genreName: name,
+                repository: PreviewFactory.repository
+            )
+        case .seeAllMovies(let title, let source):
+            seeAllMoviesDestination(title: title, source: source)
+        case .createAccount:
+            CreateAccountView(createViewModel: PreviewFactory.createEmpty())
+        }
+    }
+
+    private func movieDestination(for id: Int) -> some View {
+        let movieViewModel = PreviewFactory.movieListViewModel()
+        if movieViewModel.movie(by: id) == nil {
+            movieViewModel.cacheStub(previewMovieStub(id: id))
+        }
+
+        return MovieDetailView(
+            movieId: id,
+            movieViewModel: movieViewModel,
+            castViewModel: PreviewFactory.castViewModel(),
+            favoriteViewModel: PreviewFactory.favoritesViewModel()
+        )
+    }
+
+    private func personDestination(for id: Int) -> some View {
+        CastMemberDetailView(
+            member: previewCastMember(id: id),
+            personViewModel: PersonViewModel(repository: PreviewFactory.repository),
+            favoritePeopleVM: PreviewFactory.favoritePeopleDefaultVM(),
+            movieViewModel: PreviewFactory.movieListViewModel()
+        )
+    }
+
+    private func seeAllMoviesDestination(title: String, source: SeeAllMoviesSource) -> some View {
+        let viewModel = SeeAllMoviesViewModel(repository: PreviewFactory.repository, source: source)
+        viewModel.movies = SharedPreviewMovies.moviesList.removingDuplicateIDs()
+        return SeeAllMoviesView(viewModel: viewModel, title: title)
+    }
+
+    private func previewMovieStub(id: Int) -> Movie {
+        Movie(
+            id: id,
+            title: "Preview Movie \(id)",
+            overview: "Offline preview stub for navigation.",
+            posterPath: nil,
+            backdropPath: nil,
+            releaseDate: "2025-01-01",
+            voteAverage: 7.5,
+            genres: nil
+        )
+    }
+    
+    private func previewCastMember(id: Int) -> CastMember {
+        if let castMember = MovieCreditsPreviewData.starWarsCredits().cast.first(where: { $0.id == id }) {
+            return castMember
+        }
+
+        return CastMember(
+            id: id,
+            name: "Preview Person \(id)",
+            character: nil,
+            profilePath: nil
+        )
     }
 }

--- a/CineMate/CineMate/Features/Previews/Factory/PreviewFactory+CastViewModel.swift
+++ b/CineMate/CineMate/Features/Previews/Factory/PreviewFactory+CastViewModel.swift
@@ -11,7 +11,7 @@ import SwiftUI
 @MainActor
 extension PreviewFactory {
 
-    /// Cast view model with mock credits.
+    /// Cast view model with preview credits.
     static func castViewModel() -> CastViewModel {
         let vm = CastViewModel(repository: repository)
         vm.seedPreviewCredits(
@@ -20,17 +20,14 @@ extension PreviewFactory {
         return vm
     }
 
-    /// Cast member detail preview in a navigation stack.
+    /// Cast member detail preview.
     static func castMemberDetailView() -> some View {
-        let nav = AppNavigator()
-        return NavigationStack {
-            CastMemberDetailView(
-                member: CastMemberPreviewData.markHamill,
-                personViewModel: .preview,
-                favoritePeopleVM: favoritePeopleDefaultVM(),
-                movieViewModel: movieListViewModel()
-            )
-        }
-        .environmentObject(nav)
+        CastMemberDetailView(
+            member: CastMemberPreviewData.markHamill,
+            personViewModel: .preview,
+            favoritePeopleVM: favoritePeopleDefaultVM(),
+            movieViewModel: movieListViewModel()
+        )
+        .withPreviewNavigation()
     }
 }

--- a/CineMate/CineMate/Features/Previews/Mocks/MockMovieRepository.swift
+++ b/CineMate/CineMate/Features/Previews/Mocks/MockMovieRepository.swift
@@ -7,22 +7,8 @@
 
 import Foundation
 
-/// **MockMovieRepository**
-///
-/// Provides mocked movie data with simulated network delays for previews and testing.
-///
-/// ### Responsibilities
-/// - Simulate TMDB API calls without real network usage
-/// - Introduce small delays to mimic realistic async behavior
-/// - Provide predictable static data for all endpoints
-///
-/// ### Usage
-/// ```swift
-/// let repository = MockMovieRepository()
-/// Task {
-///     let movies = try await repository.fetchMovies(category: .popular, page: 1)
-/// }
-/// ```
+/// Mock repository for previews and tests.
+/// Returns fixed data with short delays.
 final class MockMovieRepository: MovieProtocol {
 
     func searchMovies(query: String, page: Int) async throws -> MovieResult {
@@ -37,30 +23,11 @@ final class MockMovieRepository: MovieProtocol {
                 $0.title.lowercased().contains(normalizedQuery)
             }
         }
-
-        let pageSize = 6
-        let safePage = max(1, page)
-        let startIndex = (safePage - 1) * pageSize
-        let pageResults: [Movie]
-        if startIndex < allMovies.count {
-            let endIndex = min(startIndex + pageSize, allMovies.count)
-            pageResults = Array(allMovies[startIndex..<endIndex])
-        } else {
-            pageResults = []
-        }
-
-        let totalPages = max(1, Int(ceil(Double(allMovies.count) / Double(pageSize))))
-
-        return MovieResult(
-            page: safePage,
-            results: pageResults,
-            totalPages: totalPages,
-            totalResults: allMovies.count
-        )
+        return pagedResult(from: allMovies, page: page, pageSize: 6)
     }
 
     // MARK: - Mock Delay Configuration
-    /// Centralized mock delays for consistent simulation
+    /// Small delays for preview and test flows.
     private enum Delay {
         static let veryShort: UInt64 = 150_000_000 // 0.15s - UI quick feedback
         static let short: UInt64 = 200_000_000     // 0.2s  - lightweight fetch
@@ -72,28 +39,7 @@ final class MockMovieRepository: MovieProtocol {
     // MARK: - Paging
     func fetchMovies(category: MovieCategory, page: Int) async throws -> MovieResult {
         try await Task.sleep(nanoseconds: Delay.veryLong)
-
-        let allMovies = SharedPreviewMovies.moviesList
-        let pageSize = 3
-        let safePage = max(1, page)
-        let startIndex = (safePage - 1) * pageSize
-
-        let pageResults: [Movie]
-        if startIndex < allMovies.count {
-            let endIndex = min(startIndex + pageSize, allMovies.count)
-            pageResults = Array(allMovies[startIndex..<endIndex])
-        } else {
-            pageResults = []
-        }
-
-        let totalPages = max(1, Int(ceil(Double(allMovies.count) / Double(pageSize))))
-
-        return MovieResult(
-            page: safePage,
-            results: pageResults,
-            totalPages: totalPages,
-            totalResults: allMovies.count
-        )
+        return pagedResult(from: SharedPreviewMovies.moviesList, page: page, pageSize: 3)
     }
 
     // MARK: - Movies
@@ -159,32 +105,27 @@ final class MockMovieRepository: MovieProtocol {
     // MARK: - Misc
     func fetchNowPlayingMovies(page: Int, region: String?) async throws -> MovieResult {
         try await Task.sleep(nanoseconds: Delay.long)
-
-        let allMovies = Array(SharedPreviewMovies.moviesList.reversed())
-        let pageSize = 3
-        let safePage = max(1, page)
-        let startIndex = (safePage - 1) * pageSize
-
-        let pageResults: [Movie]
-        if startIndex < allMovies.count {
-            let endIndex = min(startIndex + pageSize, allMovies.count)
-            pageResults = Array(allMovies[startIndex..<endIndex])
-        } else {
-            pageResults = []
-        }
-
-        let totalPages = max(1, Int(ceil(Double(allMovies.count) / Double(pageSize))))
-
-        return MovieResult(
-            page: safePage,
-            results: pageResults,
-            totalPages: totalPages,
-            totalResults: allMovies.count
-        )
+        return pagedResult(from: Array(SharedPreviewMovies.moviesList.reversed()), page: page, pageSize: 3)
     }
 
     func fetchGenres() async throws -> [Genre] {
         try await Task.sleep(nanoseconds: Delay.short)
         return GenrePreviewData.genres
+    }
+
+    private func pagedResult(from movies: [Movie], page: Int, pageSize: Int) -> MovieResult {
+        let safePageSize = max(1, pageSize)
+        let safePage = max(1, page)
+        let startIndex = (safePage - 1) * safePageSize
+        let endIndex = min(startIndex + safePageSize, movies.count)
+        let pageResults = startIndex < movies.count ? Array(movies[startIndex..<endIndex]) : []
+        let totalPages = max(1, (movies.count + safePageSize - 1) / safePageSize)
+
+        return MovieResult(
+            page: safePage,
+            results: pageResults,
+            totalPages: totalPages,
+            totalResults: movies.count
+        )
     }
 }

--- a/CineMate/CineMateTests/SearchViewModelTests.swift
+++ b/CineMate/CineMateTests/SearchViewModelTests.swift
@@ -295,15 +295,67 @@ final class DiscoverViewModelRoutingTests: XCTestCase {
     }
 }
 
-private actor DiscoverRoutingRepository: MovieProtocol {
+private protocol UnimplementedMovieRepository: MovieProtocol {}
+
+private extension UnimplementedMovieRepository {
+    func fetchMovies(category: MovieCategory, page: Int) async throws -> MovieResult {
+        throw SearchTestError.unimplemented
+    }
+
+    func fetchMovieDetails(for movieId: Int) async throws -> MovieDetail {
+        throw SearchTestError.unimplemented
+    }
+
+    func fetchMovieCredits(for movieId: Int) async throws -> MovieCredits {
+        throw SearchTestError.unimplemented
+    }
+
+    func fetchMovieVideos(for movieId: Int) async throws -> [MovieVideo] {
+        throw SearchTestError.unimplemented
+    }
+
+    func fetchRecommendedMovies(for movieId: Int) async throws -> [Movie] {
+        throw SearchTestError.unimplemented
+    }
+
+    func fetchWatchProviders(for movieId: Int) async throws -> WatchProviderAvailability {
+        throw SearchTestError.unimplemented
+    }
+
+    func fetchPersonDetail(for personId: Int) async throws -> PersonDetail {
+        throw SearchTestError.unimplemented
+    }
+
+    func fetchPersonMovieCredits(for personId: Int) async throws -> [PersonMovieCredit] {
+        throw SearchTestError.unimplemented
+    }
+
+    func fetchPersonExternalIDs(for personId: Int) async throws -> PersonExternalIDs {
+        throw SearchTestError.unimplemented
+    }
+
+    func searchMovies(query: String, page: Int) async throws -> MovieResult {
+        throw SearchTestError.unimplemented
+    }
+
+    func discoverMovies(filters: [URLQueryItem]) async throws -> [Movie] {
+        throw SearchTestError.unimplemented
+    }
+
+    func fetchNowPlayingMovies(page: Int, region: String?) async throws -> MovieResult {
+        throw SearchTestError.unimplemented
+    }
+
+    func fetchGenres() async throws -> [Genre] {
+        []
+    }
+}
+
+private actor DiscoverRoutingRepository: UnimplementedMovieRepository {
     struct Snapshot {
         let discoverCalls: [[URLQueryItem]]
         let categoryCalls: [MovieCategory]
         let nowPlayingCallCount: Int
-    }
-
-    private enum RepositoryError: Error {
-        case unimplemented
     }
 
     private var discoverCalls: [[URLQueryItem]] = []
@@ -323,79 +375,30 @@ private actor DiscoverRoutingRepository: MovieProtocol {
         categoryCalls.append(category)
         return MovieResult(
             page: page,
-            results: [makeMovie(title: "\(category.displayName) \(page)")],
+            results: [SearchTestMovieFactory.movie(id: takeNextMovieID(), title: "\(category.displayName) \(page)")],
             totalPages: 2,
             totalResults: 2
         )
     }
 
-    func fetchMovieDetails(for movieId: Int) async throws -> MovieDetail {
-        throw RepositoryError.unimplemented
-    }
-
-    func fetchMovieCredits(for movieId: Int) async throws -> MovieCredits {
-        throw RepositoryError.unimplemented
-    }
-
-    func fetchMovieVideos(for movieId: Int) async throws -> [MovieVideo] {
-        throw RepositoryError.unimplemented
-    }
-
-    func fetchRecommendedMovies(for movieId: Int) async throws -> [Movie] {
-        throw RepositoryError.unimplemented
-    }
-
-    func fetchWatchProviders(for movieId: Int) async throws -> WatchProviderAvailability {
-        throw RepositoryError.unimplemented
-    }
-
-    func fetchPersonDetail(for personId: Int) async throws -> PersonDetail {
-        throw RepositoryError.unimplemented
-    }
-
-    func fetchPersonMovieCredits(for personId: Int) async throws -> [PersonMovieCredit] {
-        throw RepositoryError.unimplemented
-    }
-
-    func fetchPersonExternalIDs(for personId: Int) async throws -> PersonExternalIDs {
-        throw RepositoryError.unimplemented
-    }
-
-    func searchMovies(query: String, page: Int) async throws -> MovieResult {
-        throw RepositoryError.unimplemented
-    }
-
     func discoverMovies(filters: [URLQueryItem]) async throws -> [Movie] {
         discoverCalls.append(filters)
-        return [makeMovie(title: "Discover \(discoverCalls.count)")]
+        return [SearchTestMovieFactory.movie(id: takeNextMovieID(), title: "Discover \(discoverCalls.count)")]
     }
 
     func fetchNowPlayingMovies(page: Int, region: String?) async throws -> MovieResult {
         nowPlayingCallCount += 1
         return MovieResult(
             page: max(1, page),
-            results: [makeMovie(title: "Now Playing \(page)")],
+            results: [SearchTestMovieFactory.movie(id: takeNextMovieID(), title: "Now Playing \(page)")],
             totalPages: 2,
             totalResults: 2
         )
     }
 
-    func fetchGenres() async throws -> [Genre] {
-        []
-    }
-
-    private func makeMovie(title: String) -> Movie {
+    private func takeNextMovieID() -> Int {
         defer { nextMovieID += 1 }
-        return Movie(
-            id: nextMovieID,
-            title: title,
-            overview: nil,
-            posterPath: nil,
-            backdropPath: nil,
-            releaseDate: nil,
-            voteAverage: nil,
-            genres: nil
-        )
+        return nextMovieID
     }
 }
 
@@ -465,11 +468,7 @@ final class GenreDetailViewModelEndpointTests: XCTestCase {
     }
 }
 
-private actor GenreDetailRoutingRepository: MovieProtocol {
-    private enum RepositoryError: Error {
-        case unimplemented
-    }
-
+private actor GenreDetailRoutingRepository: UnimplementedMovieRepository {
     private var discoverCalls: [[URLQueryItem]] = []
     private var nextMovieID = 10_000
 
@@ -477,71 +476,14 @@ private actor GenreDetailRoutingRepository: MovieProtocol {
         discoverCalls
     }
 
-    func fetchMovies(category: MovieCategory, page: Int) async throws -> MovieResult {
-        throw RepositoryError.unimplemented
-    }
-
-    func fetchMovieDetails(for movieId: Int) async throws -> MovieDetail {
-        throw RepositoryError.unimplemented
-    }
-
-    func fetchMovieCredits(for movieId: Int) async throws -> MovieCredits {
-        throw RepositoryError.unimplemented
-    }
-
-    func fetchMovieVideos(for movieId: Int) async throws -> [MovieVideo] {
-        throw RepositoryError.unimplemented
-    }
-
-    func fetchRecommendedMovies(for movieId: Int) async throws -> [Movie] {
-        throw RepositoryError.unimplemented
-    }
-
-    func fetchWatchProviders(for movieId: Int) async throws -> WatchProviderAvailability {
-        throw RepositoryError.unimplemented
-    }
-
-    func fetchPersonDetail(for personId: Int) async throws -> PersonDetail {
-        throw RepositoryError.unimplemented
-    }
-
-    func fetchPersonMovieCredits(for personId: Int) async throws -> [PersonMovieCredit] {
-        throw RepositoryError.unimplemented
-    }
-
-    func fetchPersonExternalIDs(for personId: Int) async throws -> PersonExternalIDs {
-        throw RepositoryError.unimplemented
-    }
-
-    func searchMovies(query: String, page: Int) async throws -> MovieResult {
-        throw RepositoryError.unimplemented
-    }
-
     func discoverMovies(filters: [URLQueryItem]) async throws -> [Movie] {
         discoverCalls.append(filters)
-        return [makeMovie(title: "Discover \(discoverCalls.count)")]
+        return [SearchTestMovieFactory.movie(id: takeNextMovieID(), title: "Discover \(discoverCalls.count)")]
     }
 
-    func fetchNowPlayingMovies(page: Int, region: String?) async throws -> MovieResult {
-        throw RepositoryError.unimplemented
-    }
-
-    func fetchGenres() async throws -> [Genre] {
-        []
-    }
-
-    private func makeMovie(title: String) -> Movie {
+    private func takeNextMovieID() -> Int {
         defer { nextMovieID += 1 }
-        return Movie(
-            id: nextMovieID,
-            title: title,
-            overview: nil,
-            posterPath: nil,
-            backdropPath: nil,
-            releaseDate: nil,
-            voteAverage: nil,
-            genres: nil
-        )
+        return nextMovieID
     }
 }
 


### PR DESCRIPTION
- unify preview environment setup for navigation and toast state
- route preview view models through mock repositories to avoid canvas crashes
- extract shared query and pagination helpers to remove duplicated code
- move the register prompt lower in the login view
- simplify inline documentation in touched files