### PR TITLE
feat: add password reset and email change

### DIFF
--- a/CineMate/CineMate.xcodeproj/project.pbxproj
+++ b/CineMate/CineMate.xcodeproj/project.pbxproj
@@ -11,7 +11,6 @@
 		03046E482E1311AD0024AD46 /* Genre.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03046E472E1311AD0024AD46 /* Genre.swift */; };
 		03046E4A2E1315A40024AD46 /* Genre+Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03046E492E1315A40024AD46 /* Genre+Preview.swift */; };
 		03046E4C2E13202D0024AD46 /* GenreDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03046E4B2E13202D0024AD46 /* GenreDetailView.swift */; };
-		0A9F3C022E7600A400A1B2C3 /* GenreDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9F3C012E7600A400A1B2C3 /* GenreDetailViewModel.swift */; };
 		030552682E64502400DE475F /* FeatureGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030552672E64502400DE475F /* FeatureGate.swift */; };
 		030599722E1EF9AC00626215 /* DiscoverViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030599712E1EF9AC00626215 /* DiscoverViewModel.swift */; };
 		030599742E1F04DA00626215 /* DiscoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030599732E1F04DA00626215 /* DiscoverView.swift */; };
@@ -254,6 +253,7 @@
 		03FE32342E07394C00C9B356 /* PersonDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FE32332E07394C00C9B356 /* PersonDetail.swift */; };
 		03FE32362E07414400C9B356 /* PersonViewModel+Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FE32352E07414400C9B356 /* PersonViewModel+Preview.swift */; };
 		03FE32382E07416900C9B356 /* PersonViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FE32372E07416900C9B356 /* PersonViewModel.swift */; };
+		0A9F3C022E7600A400A1B2C3 /* GenreDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9F3C012E7600A400A1B2C3 /* GenreDetailViewModel.swift */; };
 		9A1F1B3F2F01000100A1B2C3 /* SearchViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1F1B3C2F01000100A1B2C3 /* SearchViewModelTests.swift */; };
 		9A1F1B402F01000100A1B2C3 /* SearchValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1F1B3D2F01000100A1B2C3 /* SearchValidatorTests.swift */; };
 		9A1F1B412F01000100A1B2C3 /* SearchTestDoubles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1F1B3E2F01000100A1B2C3 /* SearchTestDoubles.swift */; };
@@ -275,7 +275,6 @@
 		03046E472E1311AD0024AD46 /* Genre.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Genre.swift; sourceTree = "<group>"; };
 		03046E492E1315A40024AD46 /* Genre+Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Genre+Preview.swift"; sourceTree = "<group>"; };
 		03046E4B2E13202D0024AD46 /* GenreDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenreDetailView.swift; sourceTree = "<group>"; };
-		0A9F3C012E7600A400A1B2C3 /* GenreDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenreDetailViewModel.swift; sourceTree = "<group>"; };
 		030552672E64502400DE475F /* FeatureGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureGate.swift; sourceTree = "<group>"; };
 		030599712E1EF9AC00626215 /* DiscoverViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverViewModel.swift; sourceTree = "<group>"; };
 		030599732E1F04DA00626215 /* DiscoverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverView.swift; sourceTree = "<group>"; };
@@ -518,6 +517,7 @@
 		03FE32332E07394C00C9B356 /* PersonDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonDetail.swift; sourceTree = "<group>"; };
 		03FE32352E07414400C9B356 /* PersonViewModel+Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersonViewModel+Preview.swift"; sourceTree = "<group>"; };
 		03FE32372E07416900C9B356 /* PersonViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonViewModel.swift; sourceTree = "<group>"; };
+		0A9F3C012E7600A400A1B2C3 /* GenreDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenreDetailViewModel.swift; sourceTree = "<group>"; };
 		9A1F1B342F01000100A1B2C3 /* CineMateTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CineMateTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9A1F1B3C2F01000100A1B2C3 /* SearchViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModelTests.swift; sourceTree = "<group>"; };
 		9A1F1B3D2F01000100A1B2C3 /* SearchValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchValidatorTests.swift; sourceTree = "<group>"; };
@@ -2090,7 +2090,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2120,7 +2120,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/CineMate/CineMate.xcodeproj/project.pbxproj
+++ b/CineMate/CineMate.xcodeproj/project.pbxproj
@@ -178,6 +178,7 @@
 		03CB4AAA2E18761C0080EE84 /* FavoriteMoviesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CB4AA92E18761C0080EE84 /* FavoriteMoviesView.swift */; };
 		03CB4AAC2E1876390080EE84 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CB4AAB2E1876390080EE84 /* SearchView.swift */; };
 		03CB4AAE2E1876500080EE84 /* AccountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CB4AAD2E1876500080EE84 /* AccountView.swift */; };
+		A1B2C3D52F70000100ABCDEF /* ChangeEmailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42F70000100ABCDEF /* ChangeEmailSheet.swift */; };
 		03CC7E242E22F3070045E678 /* DiscoverHorrorPreviewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CC7E232E22F3070045E678 /* DiscoverHorrorPreviewData.swift */; };
 		03CC7E262E22F4F30045E678 /* DiscoverContentView+Previews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CC7E252E22F4F30045E678 /* DiscoverContentView+Previews.swift */; };
 		03CCDE882E5E4136004F3848 /* View+Focus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CCDE872E5E4136004F3848 /* View+Focus.swift */; };
@@ -444,6 +445,7 @@
 		03CB4AA92E18761C0080EE84 /* FavoriteMoviesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteMoviesView.swift; sourceTree = "<group>"; };
 		03CB4AAB2E1876390080EE84 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 		03CB4AAD2E1876500080EE84 /* AccountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountView.swift; sourceTree = "<group>"; };
+		A1B2C3D42F70000100ABCDEF /* ChangeEmailSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeEmailSheet.swift; sourceTree = "<group>"; };
 		03CC7E232E22F3070045E678 /* DiscoverHorrorPreviewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverHorrorPreviewData.swift; sourceTree = "<group>"; };
 		03CC7E252E22F4F30045E678 /* DiscoverContentView+Previews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiscoverContentView+Previews.swift"; sourceTree = "<group>"; };
 		03CCDE872E5E4136004F3848 /* View+Focus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Focus.swift"; sourceTree = "<group>"; };
@@ -901,6 +903,7 @@
 				032BAF812E53AFC7001077A8 /* LoginView.swift */,
 				0397B36F2E5517E400065408 /* CreateAccountView.swift */,
 				03CB4AAD2E1876500080EE84 /* AccountView.swift */,
+				A1B2C3D42F70000100ABCDEF /* ChangeEmailSheet.swift */,
 				036E06AB2E5B97B6006BBA92 /* ResetPasswordSheet.swift */,
 			);
 			path = Views;
@@ -1820,6 +1823,7 @@
 				030289CA2E52768B00F8AF00 /* FirebaseAuthService.swift in Sources */,
 				033277EF2E15BF5700E5A226 /* WatchProviderListView+Previews.swift in Sources */,
 				03CB4AAE2E1876500080EE84 /* AccountView.swift in Sources */,
+				A1B2C3D52F70000100ABCDEF /* ChangeEmailSheet.swift in Sources */,
 				0305997A2E1F05A500626215 /* DiscoverView+Previews.swift in Sources */,
 				03E090DB2E25A2AE00ECBF5F /* GenreChipView+Previews.swift in Sources */,
 				03F3AD8D2E11C1FA00B63AA2 /* ShareLinkButtonView.swift in Sources */,

--- a/CineMate/CineMate/Core/Firebase/Auth/Models/AuthError.swift
+++ b/CineMate/CineMate/Core/Firebase/Auth/Models/AuthError.swift
@@ -13,7 +13,7 @@ enum AuthAppError: LocalizedError, Equatable {
 
     case emailNotVerified
     case invalidEmail
-    case invalidCredentials      // wrong password or user not found
+    case invalidCredentials
     case emailInUse
     case weakPassword
     case network
@@ -53,7 +53,7 @@ enum AuthAppError: LocalizedError, Equatable {
         if case .cancelled = self { return true } else { return false }
     }
 
-    /// Maps any error into an `AuthAppError`.
+    /// Maps any error to an app auth error.
     static func mapToAppError(_ error: Error) -> AuthAppError {
         if error is PreviewAuthError { return .preview }
         if error is EmailNotVerifiedError { return .emailNotVerified }
@@ -69,6 +69,13 @@ enum AuthAppError: LocalizedError, Equatable {
         }
         if nsError.domain == "com.google.GIDSignIn" {
             return .googleSignInFailed
+        }
+
+        // Firebase sometimes returns this message in a wrapped error domain.
+        // Treat it as invalid credentials for a clearer UI message.
+        let normalizedDescription = nsError.localizedDescription.lowercased()
+        if normalizedDescription.contains("supplied auth credential is malformed or has expired") {
+            return .invalidCredentials
         }
 
         guard nsError.domain == AuthErrorDomain,
@@ -88,6 +95,10 @@ enum AuthAppError: LocalizedError, Equatable {
             return .unknown("No signed-in account found")
         case .noCurrentUserEmail:
             return .unknown("No email address found for this account")
+        case .emailChangeUnavailable:
+            return .unknown("Email change is only available for email accounts")
+        case .emailUnchanged:
+            return .unknown("Enter a different email address")
         case .passwordResetUnavailable:
             return .unknown("Password reset is only available for email accounts")
         case .unexpectedSignedInUser:
@@ -138,6 +149,10 @@ enum AuthServiceError: Error {
     case noCurrentUser
     /// Current user has no email in Firebase Auth.
     case noCurrentUserEmail
+    /// Current provider does not support email change.
+    case emailChangeUnavailable
+    /// The new email is the same as the current email.
+    case emailUnchanged
     /// Current provider does not support password reset.
     case passwordResetUnavailable
     /// Create account was called while a regular user is signed in.

--- a/CineMate/CineMate/Core/Firebase/Auth/Models/AuthError.swift
+++ b/CineMate/CineMate/Core/Firebase/Auth/Models/AuthError.swift
@@ -8,24 +8,22 @@
 import Foundation
 import FirebaseAuth
 
-/// App level auth errors for the UI.
-/// This type maps Firebase and Google errors to short user messages.
+/// Auth errors used by the UI.
 enum AuthAppError: LocalizedError, Equatable {
 
-    // Core error cases we present in the UI
     case emailNotVerified
     case invalidEmail
-    case invalidCredentials      // wrong password OR user not found
+    case invalidCredentials      // wrong password or user not found
     case emailInUse
     case weakPassword
     case network
-    case accountDisabled         // disabled in backend
-    case tooManyRequests         // throttled/abuse protection
-    case providerMismatch        // account exists with a different sign-in method
+    case accountDisabled
+    case tooManyRequests
+    case providerMismatch
     case reauthenticationRequired
     case providerUnavailable
     case googleSignInFailed
-    case cancelled               // user cancelled a web/Google sign-in flow
+    case cancelled
     case preview
     case unknown(String)
 
@@ -55,12 +53,8 @@ enum AuthAppError: LocalizedError, Equatable {
         if case .cancelled = self { return true } else { return false }
     }
 
-    /// Maps any Error to an AuthAppError.
-    /// App specific errors are checked first.
-    /// Then network and Firebase errors are checked.
-    /// Unknown errors fall back to unknown with the original message.
+    /// Maps any error into an `AuthAppError`.
     static func mapToAppError(_ error: Error) -> AuthAppError {
-        // 1) Our sentinels
         if error is PreviewAuthError { return .preview }
         if error is EmailNotVerifiedError { return .emailNotVerified }
         if error is UserCancelledSignInError { return .cancelled }
@@ -69,7 +63,6 @@ enum AuthAppError: LocalizedError, Equatable {
             return mapServiceError(serviceError)
         }
 
-        // 2) Generic network
         let nsError = error as NSError
         if nsError.domain == NSURLErrorDomain {
             return .network
@@ -78,10 +71,8 @@ enum AuthAppError: LocalizedError, Equatable {
             return .googleSignInFailed
         }
 
-        // 3) Firebase Auth mapping
         guard nsError.domain == AuthErrorDomain,
               let authErrorCode = AuthErrorCode(_bridgedNSError: nsError) else {
-            // 4) Fallback
             return .unknown(nsError.localizedDescription)
         }
         return mapFirebaseAuthError(authErrorCode)
@@ -95,6 +86,10 @@ enum AuthAppError: LocalizedError, Equatable {
         switch error {
         case .noCurrentUser:
             return .unknown("No signed-in account found")
+        case .noCurrentUserEmail:
+            return .unknown("No email address found for this account")
+        case .passwordResetUnavailable:
+            return .unknown("Password reset is only available for email accounts")
         case .unexpectedSignedInUser:
             return .unknown("Sign out and try again")
         }
@@ -122,25 +117,29 @@ enum AuthAppError: LocalizedError, Equatable {
     }
 }
 
-/// Used in previews to block real auth calls.
+/// Preview only error for blocked auth calls.
 struct PreviewAuthError: LocalizedError {
     var errorDescription: String? { "Auth is unavailable in Xcode Previews." }
 }
 
-/// Used when the user must verify email before sign in.
+/// Error for unverified email sign in.
 struct EmailNotVerifiedError: LocalizedError {
     var errorDescription: String? { "Please verify your email before signing in." }
 }
 
-/// Used when the user cancels a third party sign in flow.
+/// Error for cancelled third party sign in.
 struct UserCancelledSignInError: LocalizedError {
     var errorDescription: String? { "Sign-in was cancelled." }
 }
 
 /// Service level auth errors.
 enum AuthServiceError: Error {
-    /// There is no current user.
+    /// No current user.
     case noCurrentUser
-    /// Create account was called while a non guest user is already signed in.
+    /// Current user has no email in Firebase Auth.
+    case noCurrentUserEmail
+    /// Current provider does not support password reset.
+    case passwordResetUnavailable
+    /// Create account was called while a regular user is signed in.
     case unexpectedSignedInUser
 }

--- a/CineMate/CineMate/Core/Firebase/Auth/Services/FirebaseAuthService.swift
+++ b/CineMate/CineMate/Core/Firebase/Auth/Services/FirebaseAuthService.swift
@@ -13,21 +13,21 @@ import UIKit
 /// Auth service for sign in and account actions.
 /// In previews it throws preview errors instead of calling Firebase.
 final class FirebaseAuthService {
-    
+
     // MARK: - State & Identity
-    
+
     /// True when the current user is a guest account.
     var isAnonymous: Bool {
         guard !ProcessInfo.processInfo.isPreview else { return false }
         return Auth.auth().currentUser?.isAnonymous == true
     }
-    
+
     /// Current user ID when signed in.
     var currentUserID: String? {
         guard !ProcessInfo.processInfo.isPreview else { return nil }
         return Auth.auth().currentUser?.uid
     }
-    
+
     /// Current user email when available.
     var currentUserEmail: String? {
         guard !ProcessInfo.processInfo.isPreview else { return nil }
@@ -35,9 +35,9 @@ final class FirebaseAuthService {
         guard let email, !email.isEmpty else { return nil }
         return email
     }
-    
+
     /// True when the current account can receive a password reset email.
-    /// The account must use email and password sign in.
+    /// Requires email and password sign in.
     var canSendPasswordReset: Bool {
         guard !ProcessInfo.processInfo.isPreview else { return false }
         guard let user = Auth.auth().currentUser, !user.isAnonymous else { return false }
@@ -45,9 +45,14 @@ final class FirebaseAuthService {
         guard providers.contains("password") else { return false }
         return !(user.email ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
-    
+
+    /// True when the current account can request an email change.
+    var canChangeEmail: Bool {
+        canSendPasswordReset
+    }
+
     // MARK: - Session
-    
+
     /// Returns the signed in user ID.
     /// If no user exists, it starts a guest session.
     func isLoggedIn() async throws -> String {
@@ -56,49 +61,62 @@ final class FirebaseAuthService {
         let result = try await Auth.auth().signInAnonymously()
         return result.user.uid
     }
-    
+
     /// Starts a guest session and returns the user ID.
     /// If a regular user is active, it signs out first.
     func signInAnonymously() async throws -> String {
         guard !ProcessInfo.processInfo.isPreview else { throw PreviewAuthError() }
         let auth = Auth.auth()
-        
+
         if let currentUser = auth.currentUser {
             if currentUser.isAnonymous { return currentUser.uid }
             try signOutCurrentUser(auth: auth)
         }
-        
+
         let res = try await auth.signInAnonymously()
         return res.user.uid
     }
-    
+
     /// Signs out the current user.
     func signOut() throws {
         guard !ProcessInfo.processInfo.isPreview else { return }
         try signOutCurrentUser(auth: Auth.auth())
     }
-    
+
     // MARK: - Email/Password
-    
+
     /// Signs in with email and password.
     /// Unverified users are signed out and return `EmailNotVerifiedError`.
     func signIn(email: String, password: String) async throws -> String {
         guard !ProcessInfo.processInfo.isPreview else { throw PreviewAuthError() }
-        let result = try await Auth.auth().signIn(withEmail: email, password: password)
-        
-        try await result.user.reload()
-        if !result.user.isEmailVerified {
-            try signOut()
-            throw EmailNotVerifiedError()
+        let sanitizedEmail = email
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        logAuth("signIn start email=\(maskedEmail(sanitizedEmail))")
+
+        do {
+            let result = try await Auth.auth().signIn(withEmail: email, password: password)
+            try await result.user.reload()
+            if !result.user.isEmailVerified {
+                logAuth("signIn blocked email=\(maskedEmail(sanitizedEmail)) reason=emailNotVerified")
+                try signOut()
+                throw EmailNotVerifiedError()
+            }
+            logAuth("signIn success uid=\(result.user.uid.prefix(8)) email=\(maskedEmail(sanitizedEmail))")
+            return result.user.uid
+        } catch {
+            logAuth(
+                "signIn failed email=\(maskedEmail(sanitizedEmail)) \(describe(error: error))"
+            )
+            throw error
         }
-        return result.user.uid
     }
-    
+
     /// Creates an email account or upgrades a guest account.
     /// Sends a verification email and then signs out.
     func createOrUpgradeEmailAccountRequiringVerification(email: String, password: String) async throws {
         guard !ProcessInfo.processInfo.isPreview else { throw PreviewAuthError() }
-        
+
         let user = try await createOrUpgradeEmailAccount(email: email, password: password)
         do {
             try await sendVerificationEmail(to: user)
@@ -108,66 +126,104 @@ final class FirebaseAuthService {
         }
         try signOut()
     }
-    
+
     /// Sends a verification email to the current user.
     func resendVerificationEmail() async throws {
         guard !ProcessInfo.processInfo.isPreview else { throw PreviewAuthError() }
         guard let user = Auth.auth().currentUser else { throw AuthServiceError.noCurrentUser }
         try await sendVerificationEmail(to: user)
     }
-    
-    /// Signs in with email and password, sends verification email, then signs out.
-    /// Used after an unverified sign in attempt.
+
+    /// Signs in with email and password, sends a verification email, then signs out.
+    /// Used when sign in fails because the email is not verified.
     func resendVerificationEmail(email: String, password: String) async throws {
         guard !ProcessInfo.processInfo.isPreview else { throw PreviewAuthError() }
         let auth = Auth.auth()
         guard auth.currentUser == nil else { throw AuthServiceError.unexpectedSignedInUser }
-        
+
         let result = try await auth.signIn(withEmail: email, password: password)
         defer { try? signOutCurrentUser(auth: auth) }
-        
+
         try await result.user.reload()
         guard !result.user.isEmailVerified else { return }
         try await sendVerificationEmail(to: result.user)
     }
-    
+
     /// Sends a password reset email to the given address.
     func sendPasswordReset(email: String) async throws {
         guard !ProcessInfo.processInfo.isPreview else { throw PreviewAuthError() }
         try await Auth.auth().sendPasswordReset(withEmail: email)
     }
-    
+
     /// Sends a password reset email to the current user email.
     /// Works only for email and password accounts.
     /// - Returns: The email address that received the reset email.
     func sendPasswordResetToCurrentUserEmail() async throws -> String {
         guard !ProcessInfo.processInfo.isPreview else { throw PreviewAuthError() }
         guard let user = Auth.auth().currentUser else { throw AuthServiceError.noCurrentUser }
-        
+
         let providers = user.providerData.map(\.providerID)
         guard providers.contains("password") else {
             throw AuthServiceError.passwordResetUnavailable
         }
-        
+
         let email = (user.email ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         guard !email.isEmpty else { throw AuthServiceError.noCurrentUserEmail }
-        
-        try await Auth.auth().sendPasswordReset(withEmail: email)
-        return email
+
+        do {
+            try await Auth.auth().sendPasswordReset(withEmail: email)
+            logAuth("passwordReset sent email=\(maskedEmail(email))")
+            return email
+        } catch {
+            logAuth("passwordReset failed email=\(maskedEmail(email)) \(describe(error: error))")
+            throw error
+        }
     }
-    
+
+    /// Sends a verification link for changing the current user email.
+    /// The email changes only after the user confirms the link.
+    func sendChangeEmailVerification(to newEmail: String) async throws {
+        guard !ProcessInfo.processInfo.isPreview else { throw PreviewAuthError() }
+        guard canChangeEmail else { throw AuthServiceError.emailChangeUnavailable }
+        guard let user = Auth.auth().currentUser else { throw AuthServiceError.noCurrentUser }
+
+        let normalizedNewEmail = newEmail
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        let currentEmail = (user.email ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        guard normalizedNewEmail != currentEmail else { throw AuthServiceError.emailUnchanged }
+
+        logAuth(
+            "changeEmail start current=\(maskedEmail(currentEmail)) new=\(maskedEmail(normalizedNewEmail)) uid=\(user.uid.prefix(8))"
+        )
+
+        do {
+            try await sendVerificationEmail(beforeUpdatingEmail: normalizedNewEmail, to: user)
+            logAuth(
+                "changeEmail verificationSent current=\(maskedEmail(currentEmail)) new=\(maskedEmail(normalizedNewEmail))"
+            )
+        } catch {
+            logAuth(
+                "changeEmail failed current=\(maskedEmail(currentEmail)) new=\(maskedEmail(normalizedNewEmail)) \(describe(error: error))"
+            )
+            throw error
+        }
+    }
+
     // MARK: - Private
-    
+
     /// Signs out Firebase and clears cached Google session.
     private func signOutCurrentUser(auth: Auth) throws {
         try auth.signOut()
         GIDSignIn.sharedInstance.signOut()
     }
-    
+
     private func createOrUpgradeEmailAccount(email: String, password: String) async throws -> User {
         let auth = Auth.auth()
         let emailCredential = EmailAuthProvider.credential(withEmail: email, password: password)
-        
+
         if let currentUser = auth.currentUser {
             if currentUser.isAnonymous {
                 let linkResult = try await currentUser.link(with: emailCredential)
@@ -175,11 +231,11 @@ final class FirebaseAuthService {
             }
             throw AuthServiceError.unexpectedSignedInUser
         }
-        
+
         let signUpResult = try await auth.createUser(withEmail: email, password: password)
         return signUpResult.user
     }
-    
+
     private func sendVerificationEmail(to user: User) async throws {
         try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
             user.sendEmailVerification { error in
@@ -187,29 +243,57 @@ final class FirebaseAuthService {
             }
         }
     }
+
+    private func sendVerificationEmail(beforeUpdatingEmail email: String, to user: User) async throws {
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            user.sendEmailVerification(beforeUpdatingEmail: email) { error in
+                if let error { cont.resume(throwing: error) } else { cont.resume() }
+            }
+        }
+    }
+
+    private func describe(error: Error) -> String {
+        let nsError = error as NSError
+        return "domain=\(nsError.domain) code=\(nsError.code) message=\(nsError.localizedDescription)"
+    }
+
+    private func maskedEmail(_ email: String) -> String {
+        let trimmed = email.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let atIndex = trimmed.firstIndex(of: "@") else { return "***" }
+        let name = String(trimmed[..<atIndex])
+        let domain = String(trimmed[trimmed.index(after: atIndex)...])
+        let first = name.first.map(String.init) ?? ""
+        return "\(first)***@\(domain)"
+    }
+
+    private func logAuth(_ message: String) {
+#if DEBUG
+        print("[App][Auth][Service] \(message)")
+#endif
+    }
 }
 
 // MARK: - Google
 
 extension FirebaseAuthService {
-    
+
     /// Runs Google sign in and returns the Firebase user ID.
     /// If a guest user is active, it links Google to keep the same account ID.
     func signInWithGoogle(from viewController: UIViewController, using client: GoogleAuthClient) async throws -> String {
         guard !ProcessInfo.processInfo.isPreview else { throw PreviewAuthError() }
-        
+
         let tokens = try await client.signIn(from: viewController)
         let credential = GoogleAuthProvider.credential(
             withIDToken: tokens.idToken,
             accessToken: tokens.accessToken
         )
-        
+
         let auth = Auth.auth()
         if let currentUser = auth.currentUser, currentUser.isAnonymous {
             let linked = try await currentUser.link(with: credential)
             return linked.user.uid
         }
-        
+
         let result = try await auth.signIn(with: credential)
         return result.user.uid
     }

--- a/CineMate/CineMate/Core/Firebase/Auth/Services/FirebaseAuthService.swift
+++ b/CineMate/CineMate/Core/Firebase/Auth/Services/FirebaseAuthService.swift
@@ -83,6 +83,20 @@ final class FirebaseAuthService {
         try signOutCurrentUser(auth: Auth.auth())
     }
 
+    /// Reloads the current Firebase user from the server.
+    func reloadCurrentUser() async throws {
+        guard !ProcessInfo.processInfo.isPreview else { throw PreviewAuthError() }
+        guard let user = Auth.auth().currentUser else { throw AuthServiceError.noCurrentUser }
+
+        do {
+            try await user.reload()
+            logAuth("reloadCurrentUser success uid=\(user.uid.prefix(8))")
+        } catch {
+            logAuth("reloadCurrentUser failed \(describe(error: error))")
+            throw error
+        }
+    }
+
     // MARK: - Email/Password
 
     /// Signs in with email and password.

--- a/CineMate/CineMate/Core/Firebase/Auth/Services/FirebaseAuthService.swift
+++ b/CineMate/CineMate/Core/Firebase/Auth/Services/FirebaseAuthService.swift
@@ -10,30 +10,46 @@ import FirebaseAuth
 import GoogleSignIn
 import UIKit
 
-/// Small auth service used by auth view models.
-/// In previews it does not call Firebase.
+/// Auth service for sign in and account actions.
+/// In previews it throws preview errors instead of calling Firebase.
 final class FirebaseAuthService {
     
     // MARK: - State & Identity
     
-    /// True when current user is anonymous.
-    /// In previews this is always false.
+    /// True when the current user is a guest account.
     var isAnonymous: Bool {
         guard !ProcessInfo.processInfo.isPreview else { return false }
         return Auth.auth().currentUser?.isAnonymous == true
     }
     
-    /// Current user uid if signed in.
-    /// In previews this is always nil.
+    /// Current user ID when signed in.
     var currentUserID: String? {
         guard !ProcessInfo.processInfo.isPreview else { return nil }
         return Auth.auth().currentUser?.uid
     }
     
+    /// Current user email when available.
+    var currentUserEmail: String? {
+        guard !ProcessInfo.processInfo.isPreview else { return nil }
+        let email = Auth.auth().currentUser?.email?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let email, !email.isEmpty else { return nil }
+        return email
+    }
+    
+    /// True when the current account can receive a password reset email.
+    /// The account must use email and password sign in.
+    var canSendPasswordReset: Bool {
+        guard !ProcessInfo.processInfo.isPreview else { return false }
+        guard let user = Auth.auth().currentUser, !user.isAnonymous else { return false }
+        let providers = user.providerData.map(\.providerID)
+        guard providers.contains("password") else { return false }
+        return !(user.email ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+    
     // MARK: - Session
     
-    /// Returns a signed in uid.
-    /// If no user exists it signs in as anonymous.
+    /// Returns the signed in user ID.
+    /// If no user exists, it starts a guest session.
     func isLoggedIn() async throws -> String {
         guard !ProcessInfo.processInfo.isPreview else { throw PreviewAuthError() }
         if let uid = currentUserID { return uid }
@@ -41,8 +57,8 @@ final class FirebaseAuthService {
         return result.user.uid
     }
     
-    /// Starts an anonymous session and returns uid.
-    /// If a normal user is active it signs out first.
+    /// Starts a guest session and returns the user ID.
+    /// If a regular user is active, it signs out first.
     func signInAnonymously() async throws -> String {
         guard !ProcessInfo.processInfo.isPreview else { throw PreviewAuthError() }
         let auth = Auth.auth()
@@ -56,8 +72,7 @@ final class FirebaseAuthService {
         return res.user.uid
     }
     
-    /// Signs out current user.
-    /// In previews this does nothing.
+    /// Signs out the current user.
     func signOut() throws {
         guard !ProcessInfo.processInfo.isPreview else { return }
         try signOutCurrentUser(auth: Auth.auth())
@@ -66,8 +81,7 @@ final class FirebaseAuthService {
     // MARK: - Email/Password
     
     /// Signs in with email and password.
-    /// It also checks email verification.
-    /// Unverified users are signed out and get EmailNotVerifiedError.
+    /// Unverified users are signed out and return `EmailNotVerifiedError`.
     func signIn(email: String, password: String) async throws -> String {
         guard !ProcessInfo.processInfo.isPreview else { throw PreviewAuthError() }
         let result = try await Auth.auth().signIn(withEmail: email, password: password)
@@ -80,8 +94,8 @@ final class FirebaseAuthService {
         return result.user.uid
     }
     
-    /// Creates or upgrades to email account.
-    /// It sends verification email and signs out.
+    /// Creates an email account or upgrades a guest account.
+    /// Sends a verification email and then signs out.
     func createOrUpgradeEmailAccountRequiringVerification(email: String, password: String) async throws {
         guard !ProcessInfo.processInfo.isPreview else { throw PreviewAuthError() }
         
@@ -95,38 +109,56 @@ final class FirebaseAuthService {
         try signOut()
     }
     
-    /// Sends verification email to current user.
-    /// Throws when no current user exists.
+    /// Sends a verification email to the current user.
     func resendVerificationEmail() async throws {
         guard !ProcessInfo.processInfo.isPreview else { throw PreviewAuthError() }
         guard let user = Auth.auth().currentUser else { throw AuthServiceError.noCurrentUser }
         try await sendVerificationEmail(to: user)
     }
-
-    /// Re-authenticates with email/password, sends verification email, then signs out.
-    /// Designed for the signed-out login flow after an unverified sign-in attempt.
+    
+    /// Signs in with email and password, sends verification email, then signs out.
+    /// Used after an unverified sign in attempt.
     func resendVerificationEmail(email: String, password: String) async throws {
         guard !ProcessInfo.processInfo.isPreview else { throw PreviewAuthError() }
         let auth = Auth.auth()
         guard auth.currentUser == nil else { throw AuthServiceError.unexpectedSignedInUser }
-
+        
         let result = try await auth.signIn(withEmail: email, password: password)
         defer { try? signOutCurrentUser(auth: auth) }
-
+        
         try await result.user.reload()
         guard !result.user.isEmailVerified else { return }
         try await sendVerificationEmail(to: result.user)
     }
     
-    /// Sends password reset email.
+    /// Sends a password reset email to the given address.
     func sendPasswordReset(email: String) async throws {
         guard !ProcessInfo.processInfo.isPreview else { throw PreviewAuthError() }
         try await Auth.auth().sendPasswordReset(withEmail: email)
     }
     
+    /// Sends a password reset email to the current user email.
+    /// Works only for email and password accounts.
+    /// - Returns: The email address that received the reset email.
+    func sendPasswordResetToCurrentUserEmail() async throws -> String {
+        guard !ProcessInfo.processInfo.isPreview else { throw PreviewAuthError() }
+        guard let user = Auth.auth().currentUser else { throw AuthServiceError.noCurrentUser }
+        
+        let providers = user.providerData.map(\.providerID)
+        guard providers.contains("password") else {
+            throw AuthServiceError.passwordResetUnavailable
+        }
+        
+        let email = (user.email ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !email.isEmpty else { throw AuthServiceError.noCurrentUserEmail }
+        
+        try await Auth.auth().sendPasswordReset(withEmail: email)
+        return email
+    }
+    
     // MARK: - Private
     
-    /// Signs out Firebase and clears any cached Google session.
+    /// Signs out Firebase and clears cached Google session.
     private func signOutCurrentUser(auth: Auth) throws {
         try auth.signOut()
         GIDSignIn.sharedInstance.signOut()
@@ -161,10 +193,8 @@ final class FirebaseAuthService {
 
 extension FirebaseAuthService {
     
-    /// Runs Google sign in and returns Firebase uid.
-    /// The presenter is used by Google ui flow.
-    /// If an anonymous user is active, the Google credential is linked
-    /// to preserve the existing uid and user data.
+    /// Runs Google sign in and returns the Firebase user ID.
+    /// If a guest user is active, it links Google to keep the same account ID.
     func signInWithGoogle(from viewController: UIViewController, using client: GoogleAuthClient) async throws -> String {
         guard !ProcessInfo.processInfo.isPreview else { throw PreviewAuthError() }
         

--- a/CineMate/CineMate/Core/Firebase/Auth/ViewModels/AuthViewModel.swift
+++ b/CineMate/CineMate/Core/Firebase/Auth/ViewModels/AuthViewModel.swift
@@ -12,44 +12,48 @@ import FirebaseAuth
 /// Auth state for account and sign in screens.
 @MainActor
 final class AuthViewModel: ObservableObject {
-
+    private static let changeEmailCooldownSeconds = 30.0
+    
     // MARK: - UI State
-
+    
     /// Current user ID. Nil means signed out.
     @Published var currentUID: String?
-
+    
     /// True while an auth task is running.
     @Published var isAuthenticating = false
-
+    
     /// Error text shown by the UI.
     @Published var errorMessage: String?
-
+    
+    /// End time for change email cooldown.
+    private var changeEmailCooldownUntil: Date?
+    
     // MARK: - Dependencies
-
+    
     /// Auth service. Nil only in preview init.
     private let service: FirebaseAuthService?
-
+    
     // MARK: - Derived
-
+    
     var isSignedIn: Bool { currentUID != nil }
-
+    
     /// True when the current user is a guest account.
     var isGuest: Bool {
         if ProcessInfo.processInfo.isPreview { return false }
         return service?.isAnonymous ?? false
     }
-
+    
     // MARK: - Init (Production)
-
+    
     init(service: FirebaseAuthService) {
         self.service = service
         if !ProcessInfo.processInfo.isPreview {
             currentUID = service.currentUserID
         }
     }
-
+    
     // MARK: - Init (Preview)
-
+    
     init(
         simulatedUID: String? = nil,
         previewError: String? = nil,
@@ -60,9 +64,9 @@ final class AuthViewModel: ObservableObject {
         self.errorMessage = previewError
         self.isAuthenticating = previewIsAuthenticating
     }
-
+    
     // MARK: - Actions
-
+    
     /// Starts guest sign in.
     func signInAsGuest() async {
         if ProcessInfo.processInfo.isPreview {
@@ -70,7 +74,7 @@ final class AuthViewModel: ObservableObject {
             currentUID = currentUID ?? AuthPreviewData.demoUID
             return
         }
-
+        
         guard let service else { return }
         isAuthenticating = true
         defer { isAuthenticating = false }
@@ -82,19 +86,20 @@ final class AuthViewModel: ObservableObject {
             errorMessage = AuthAppError.userMessage(for: error)
         }
     }
-
+    
     /// Signs out the current user.
     func signOut() async {
         if ProcessInfo.processInfo.isPreview {
             currentUID = nil
             errorMessage = nil
+            changeEmailCooldownUntil = nil
             return
         }
-
+        
         guard let service else { return }
         isAuthenticating = true
         defer { isAuthenticating = false }
-
+        
         do {
             if service.isAnonymous {
                 _ = try await service.deleteCurrentAccountWithDataCleanup()
@@ -103,16 +108,17 @@ final class AuthViewModel: ObservableObject {
             }
             currentUID = nil
             errorMessage = nil
+            changeEmailCooldownUntil = nil
         } catch {
             errorMessage = AuthAppError.userMessage(for: error)
         }
     }
-
+    
     /// Reloads auth user data from server and refreshes local account info.
     func refreshCurrentUserFromServer() async {
         if ProcessInfo.processInfo.isPreview { return }
         guard let service, currentUID != nil else { return }
-
+        
         do {
             try await service.reloadCurrentUser()
             currentUID = service.currentUserID
@@ -127,32 +133,39 @@ final class AuthViewModel: ObservableObject {
 // MARK: - Email change API
 
 extension AuthViewModel {
-
+    
     /// Result for email change action.
     enum ChangeEmailResult {
         case verificationSent(email: String)
         case unavailable
+        case cooldown(seconds: Int)
         case needsRecentLogin
         case failure(String)
     }
-
+    
     /// Sends an email change verification link to the new address.
     func sendChangeEmailVerification(to newEmail: String) async -> ChangeEmailResult {
         if ProcessInfo.processInfo.isPreview { return .failure("Unavailable in previews") }
         guard let service, currentUID != nil else { return .failure("No current user") }
         guard service.canChangeEmail else { return .unavailable }
-
+        let cooldownSeconds = changeEmailCooldownRemainingSeconds()
+        guard cooldownSeconds == 0 else {
+            logAuth("changeEmail cooldown remaining=\(cooldownSeconds)s")
+            return .cooldown(seconds: cooldownSeconds)
+        }
+        
         let normalizedNewEmail = AuthValidator.sanitizedEmail(from: newEmail)
         guard AuthValidator.isValidEmail(normalizedNewEmail) else {
             return .failure(AuthValidator.Message.invalidEmail)
         }
-
+        
         isAuthenticating = true
         defer { isAuthenticating = false }
-
+        
         do {
             try await service.sendChangeEmailVerification(to: normalizedNewEmail)
             errorMessage = nil
+            changeEmailCooldownUntil = Date().addingTimeInterval(Self.changeEmailCooldownSeconds)
             logAuth("changeEmail verificationSent email=\(maskedEmail(normalizedNewEmail))")
             return .verificationSent(email: normalizedNewEmail)
         } catch {
@@ -167,28 +180,33 @@ extension AuthViewModel {
             return .failure(message)
         }
     }
+    
+    private func changeEmailCooldownRemainingSeconds(at date: Date = Date()) -> Int {
+        guard let changeEmailCooldownUntil else { return 0 }
+        return max(Int(ceil(changeEmailCooldownUntil.timeIntervalSince(date))), 0)
+    }
 }
 
 // MARK: - Password reset API
 
 extension AuthViewModel {
-
+    
     /// Result for password reset action.
     enum PasswordResetResult {
         case sent(email: String)
         case unavailable
         case failure(String)
     }
-
+    
     /// Sends a password reset email for the signed in account.
     func sendPasswordResetForCurrentUser() async -> PasswordResetResult {
         if ProcessInfo.processInfo.isPreview { return .failure("Unavailable in previews") }
         guard let service, currentUID != nil else { return .failure("No current user") }
         guard service.canSendPasswordReset else { return .unavailable }
-
+        
         isAuthenticating = true
         defer { isAuthenticating = false }
-
+        
         do {
             let email = try await service.sendPasswordResetToCurrentUserEmail()
             errorMessage = nil
@@ -206,33 +224,35 @@ extension AuthViewModel {
 // MARK: - Deletion API
 
 extension AuthViewModel {
-
+    
     /// Result for delete account action.
     enum DeleteAccountResult {
         case success
         case needsRecentLogin
         case failure(String)
     }
-
+    
     func deleteCurrentAccount() async -> DeleteAccountResult {
         if ProcessInfo.processInfo.isPreview { return .failure("Unavailable in previews") }
         guard let service = self.service, currentUID != nil else {
             return .failure("No current user")
         }
-
+        
         isAuthenticating = true
         defer { isAuthenticating = false }
-
+        
         do {
             let result = try await service.deleteCurrentAccountWithDataCleanup()
             switch result {
             case .success:
                 self.currentUID = nil
                 self.errorMessage = nil
+                self.changeEmailCooldownUntil = nil
                 return .success
             case .requiresRecentLogin:
                 self.currentUID = nil
                 self.errorMessage = nil
+                self.changeEmailCooldownUntil = nil
                 return .needsRecentLogin
             }
         } catch {
@@ -253,7 +273,7 @@ extension AuthViewModel {
         }
         return service?.authProviderDescription ?? "Signed out"
     }
-
+    
     /// Email shown on the account screen.
     var currentUserEmail: String? {
         if ProcessInfo.processInfo.isPreview {
@@ -261,13 +281,13 @@ extension AuthViewModel {
         }
         return service?.currentUserEmail
     }
-
+    
     /// True when this account supports password reset emails.
     var canSendPasswordReset: Bool {
         if ProcessInfo.processInfo.isPreview { return currentUID != nil }
         return service?.canSendPasswordReset ?? false
     }
-
+    
     /// True when this account supports email change.
     var canChangeEmail: Bool {
         if ProcessInfo.processInfo.isPreview { return currentUID != nil }
@@ -284,7 +304,7 @@ private extension AuthViewModel {
         if normalizedDescription.contains("supplied auth credential is malformed or has expired") {
             return "Please sign in again to change your email"
         }
-
+        
         if nsError.domain == AuthErrorDomain,
            let authErrorCode = AuthErrorCode(_bridgedNSError: nsError) {
             switch authErrorCode {
@@ -296,15 +316,15 @@ private extension AuthViewModel {
                 break
             }
         }
-
+        
         return AuthAppError.userMessage(for: error)
     }
-
+    
     func describe(error: Error) -> String {
         let nsError = error as NSError
         return "domain=\(nsError.domain) code=\(nsError.code) message=\(nsError.localizedDescription)"
     }
-
+    
     func maskedEmail(_ email: String) -> String {
         let trimmed = email.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let atIndex = trimmed.firstIndex(of: "@") else { return "***" }
@@ -313,7 +333,7 @@ private extension AuthViewModel {
         let first = name.first.map(String.init) ?? ""
         return "\(first)***@\(domain)"
     }
-
+    
     func logAuth(_ message: String) {
 #if DEBUG
         print("[App][Auth][ViewModel] \(message)")

--- a/CineMate/CineMate/Core/Firebase/Auth/ViewModels/AuthViewModel.swift
+++ b/CineMate/CineMate/Core/Firebase/Auth/ViewModels/AuthViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SwiftUI
+import FirebaseAuth
 
 /// Auth state for account and sign in screens.
 @MainActor
@@ -106,6 +107,21 @@ final class AuthViewModel: ObservableObject {
             errorMessage = AuthAppError.userMessage(for: error)
         }
     }
+
+    /// Reloads auth user data from server and refreshes local account info.
+    func refreshCurrentUserFromServer() async {
+        if ProcessInfo.processInfo.isPreview { return }
+        guard let service, currentUID != nil else { return }
+
+        do {
+            try await service.reloadCurrentUser()
+            currentUID = service.currentUserID
+            logAuth("refreshCurrentUser success uid=\(currentUID?.prefix(8) ?? "none")")
+        } catch {
+            currentUID = service.currentUserID
+            logAuth("refreshCurrentUser failed \(describe(error: error))")
+        }
+    }
 }
 
 // MARK: - Email change API
@@ -145,9 +161,9 @@ extension AuthViewModel {
                 logAuth("changeEmail needsRecentLogin")
                 return .needsRecentLogin
             }
-            let message = AuthAppError.userMessage(for: error)
+            let message = mapChangeEmailErrorMessage(for: error)
             errorMessage = message
-            logAuth("changeEmail failed message=\(message)")
+            logAuth("changeEmail failed message=\(message) \(describe(error: error))")
             return .failure(message)
         }
     }
@@ -262,6 +278,33 @@ extension AuthViewModel {
 // MARK: - Debug logging
 
 private extension AuthViewModel {
+    func mapChangeEmailErrorMessage(for error: Error) -> String {
+        let nsError = error as NSError
+        let normalizedDescription = nsError.localizedDescription.lowercased()
+        if normalizedDescription.contains("supplied auth credential is malformed or has expired") {
+            return "Please sign in again to change your email"
+        }
+
+        if nsError.domain == AuthErrorDomain,
+           let authErrorCode = AuthErrorCode(_bridgedNSError: nsError) {
+            switch authErrorCode {
+            case .invalidCredential, .requiresRecentLogin, .userTokenExpired:
+                return "Please sign in again to change your email"
+            case .invalidEmail:
+                return AuthValidator.Message.invalidEmail
+            default:
+                break
+            }
+        }
+
+        return AuthAppError.userMessage(for: error)
+    }
+
+    func describe(error: Error) -> String {
+        let nsError = error as NSError
+        return "domain=\(nsError.domain) code=\(nsError.code) message=\(nsError.localizedDescription)"
+    }
+
     func maskedEmail(_ email: String) -> String {
         let trimmed = email.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let atIndex = trimmed.firstIndex(of: "@") else { return "***" }

--- a/CineMate/CineMate/Core/Firebase/Auth/ViewModels/AuthViewModel.swift
+++ b/CineMate/CineMate/Core/Firebase/Auth/ViewModels/AuthViewModel.swift
@@ -8,53 +8,48 @@
 import Foundation
 import SwiftUI
 
-/// Main auth state view model.
-/// Owns signed in state, loading state, and auth actions.
+/// Auth state used by account and sign in screens.
 @MainActor
 final class AuthViewModel: ObservableObject {
-
-    // MARK: - UI State (observable & writable)
-
-    /// Current user id.
-    /// Nil means signed out.
+    
+    // MARK: - UI State
+    
+    /// Current user ID. Nil means signed out.
     @Published var currentUID: String?
-
-    /// True while an auth action runs.
+    
+    /// True while an auth task is running.
     @Published var isAuthenticating = false
-
-    /// Error text for UI.
+    
+    /// Error text shown by the UI.
     @Published var errorMessage: String?
-
-    // MARK: - Dependencies (production only)
-
-    /// Auth service.
-    /// Nil only in preview init.
+    
+    // MARK: - Dependencies
+    
+    /// Auth service. Nil only in preview init.
     private let service: FirebaseAuthService?
-
+    
     // MARK: - Derived
-
+    
     var isSignedIn: Bool { currentUID != nil }
-
-    /// True when current user is guest.
-    /// Always false in previews.
+    
+    /// True when the current user is a guest account.
     var isGuest: Bool {
         if ProcessInfo.processInfo.isPreview { return false }
         return service?.isAnonymous ?? false
     }
-
+    
     // MARK: - Init (Production)
-
+    
     /// Production init.
-    /// Reads current uid from the service.
     init(service: FirebaseAuthService) {
         self.service = service
         if !ProcessInfo.processInfo.isPreview {
             currentUID = service.currentUserID
         }
     }
-
+    
     // MARK: - Init (Preview)
-
+    
     /// Preview init with static values.
     init(
         simulatedUID: String? = nil,
@@ -66,19 +61,17 @@ final class AuthViewModel: ObservableObject {
         self.errorMessage = previewError
         self.isAuthenticating = previewIsAuthenticating
     }
-
+    
     // MARK: - Actions
-
-    /// Starts guest sign in flow.
+    
+    /// Starts guest sign in.
     func signInAsGuest() async {
-        // Preview state only
         if ProcessInfo.processInfo.isPreview {
-            guard errorMessage == nil else { return } // keep the “Error” preview intact
+            guard errorMessage == nil else { return }
             currentUID = currentUID ?? AuthPreviewData.demoUID
             return
         }
-
-        // Production call
+        
         guard let service else { return }
         isAuthenticating = true
         defer { isAuthenticating = false }
@@ -90,21 +83,19 @@ final class AuthViewModel: ObservableObject {
             errorMessage = AuthAppError.userMessage(for: error)
         }
     }
-
-    /// Signs out current user.
+    
+    /// Signs out the current user.
     func signOut() async {
-        // Preview state only
         if ProcessInfo.processInfo.isPreview {
             currentUID = nil
             errorMessage = nil
             return
         }
-
-        // Production call
+        
         guard let service else { return }
         isAuthenticating = true
         defer { isAuthenticating = false }
-
+        
         do {
             if service.isAnonymous {
                 _ = try await service.deleteCurrentAccountWithDataCleanup()
@@ -119,26 +110,58 @@ final class AuthViewModel: ObservableObject {
     }
 }
 
+// MARK: - Password reset API
+
+extension AuthViewModel {
+    
+    /// Result for password reset action.
+    enum PasswordResetResult {
+        case sent(email: String)
+        case unavailable
+        case failure(String)
+    }
+    
+    /// Sends a password reset email for the signed in account.
+    func sendPasswordResetForCurrentUser() async -> PasswordResetResult {
+        if ProcessInfo.processInfo.isPreview { return .failure("Unavailable in previews") }
+        guard let service, currentUID != nil else { return .failure("No current user") }
+        guard service.canSendPasswordReset else { return .unavailable }
+        
+        isAuthenticating = true
+        defer { isAuthenticating = false }
+        
+        do {
+            let email = try await service.sendPasswordResetToCurrentUserEmail()
+            errorMessage = nil
+            return .sent(email: email)
+        } catch {
+            let message = AuthAppError.userMessage(for: error)
+            errorMessage = message
+            return .failure(message)
+        }
+    }
+}
+
 // MARK: - Deletion API
 
 extension AuthViewModel {
-
+    
     /// Result for delete account action.
     enum DeleteAccountResult {
         case success
         case needsRecentLogin
         case failure(String)
     }
-
+    
     func deleteCurrentAccount() async -> DeleteAccountResult {
         if ProcessInfo.processInfo.isPreview { return .failure("Unavailable in previews") }
         guard let service = self.service, currentUID != nil else {
             return .failure("No current user")
         }
-
+        
         isAuthenticating = true
         defer { isAuthenticating = false }
-
+        
         do {
             let result = try await service.deleteCurrentAccountWithDataCleanup()
             switch result {
@@ -162,11 +185,25 @@ extension AuthViewModel {
 // MARK: - Read-only auth info
 
 extension AuthViewModel {
-    /// Provider label for account screen.
+    /// Provider label for the account screen.
     var authProviderDescription: String {
         if ProcessInfo.processInfo.isPreview {
             return currentUID == nil ? "Signed out" : "Preview user"
         }
         return service?.authProviderDescription ?? "Signed out"
+    }
+    
+    /// Email shown on the account screen.
+    var currentUserEmail: String? {
+        if ProcessInfo.processInfo.isPreview {
+            return currentUID == nil ? nil : "preview@example.com"
+        }
+        return service?.currentUserEmail
+    }
+    
+    /// True when this account supports password reset emails.
+    var canSendPasswordReset: Bool {
+        if ProcessInfo.processInfo.isPreview { return currentUID != nil }
+        return service?.canSendPasswordReset ?? false
     }
 }

--- a/CineMate/CineMate/Core/Firebase/Auth/ViewModels/AuthViewModel.swift
+++ b/CineMate/CineMate/Core/Firebase/Auth/ViewModels/AuthViewModel.swift
@@ -8,49 +8,47 @@
 import Foundation
 import SwiftUI
 
-/// Auth state used by account and sign in screens.
+/// Auth state for account and sign in screens.
 @MainActor
 final class AuthViewModel: ObservableObject {
-    
+
     // MARK: - UI State
-    
+
     /// Current user ID. Nil means signed out.
     @Published var currentUID: String?
-    
+
     /// True while an auth task is running.
     @Published var isAuthenticating = false
-    
+
     /// Error text shown by the UI.
     @Published var errorMessage: String?
-    
+
     // MARK: - Dependencies
-    
+
     /// Auth service. Nil only in preview init.
     private let service: FirebaseAuthService?
-    
+
     // MARK: - Derived
-    
+
     var isSignedIn: Bool { currentUID != nil }
-    
+
     /// True when the current user is a guest account.
     var isGuest: Bool {
         if ProcessInfo.processInfo.isPreview { return false }
         return service?.isAnonymous ?? false
     }
-    
+
     // MARK: - Init (Production)
-    
-    /// Production init.
+
     init(service: FirebaseAuthService) {
         self.service = service
         if !ProcessInfo.processInfo.isPreview {
             currentUID = service.currentUserID
         }
     }
-    
+
     // MARK: - Init (Preview)
-    
-    /// Preview init with static values.
+
     init(
         simulatedUID: String? = nil,
         previewError: String? = nil,
@@ -61,9 +59,9 @@ final class AuthViewModel: ObservableObject {
         self.errorMessage = previewError
         self.isAuthenticating = previewIsAuthenticating
     }
-    
+
     // MARK: - Actions
-    
+
     /// Starts guest sign in.
     func signInAsGuest() async {
         if ProcessInfo.processInfo.isPreview {
@@ -71,7 +69,7 @@ final class AuthViewModel: ObservableObject {
             currentUID = currentUID ?? AuthPreviewData.demoUID
             return
         }
-        
+
         guard let service else { return }
         isAuthenticating = true
         defer { isAuthenticating = false }
@@ -83,7 +81,7 @@ final class AuthViewModel: ObservableObject {
             errorMessage = AuthAppError.userMessage(for: error)
         }
     }
-    
+
     /// Signs out the current user.
     func signOut() async {
         if ProcessInfo.processInfo.isPreview {
@@ -91,11 +89,11 @@ final class AuthViewModel: ObservableObject {
             errorMessage = nil
             return
         }
-        
+
         guard let service else { return }
         isAuthenticating = true
         defer { isAuthenticating = false }
-        
+
         do {
             if service.isAnonymous {
                 _ = try await service.deleteCurrentAccountWithDataCleanup()
@@ -110,33 +108,80 @@ final class AuthViewModel: ObservableObject {
     }
 }
 
+// MARK: - Email change API
+
+extension AuthViewModel {
+
+    /// Result for email change action.
+    enum ChangeEmailResult {
+        case verificationSent(email: String)
+        case unavailable
+        case needsRecentLogin
+        case failure(String)
+    }
+
+    /// Sends an email change verification link to the new address.
+    func sendChangeEmailVerification(to newEmail: String) async -> ChangeEmailResult {
+        if ProcessInfo.processInfo.isPreview { return .failure("Unavailable in previews") }
+        guard let service, currentUID != nil else { return .failure("No current user") }
+        guard service.canChangeEmail else { return .unavailable }
+
+        let normalizedNewEmail = AuthValidator.sanitizedEmail(from: newEmail)
+        guard AuthValidator.isValidEmail(normalizedNewEmail) else {
+            return .failure(AuthValidator.Message.invalidEmail)
+        }
+
+        isAuthenticating = true
+        defer { isAuthenticating = false }
+
+        do {
+            try await service.sendChangeEmailVerification(to: normalizedNewEmail)
+            errorMessage = nil
+            logAuth("changeEmail verificationSent email=\(maskedEmail(normalizedNewEmail))")
+            return .verificationSent(email: normalizedNewEmail)
+        } catch {
+            if service.isRecentLoginRequired(error) {
+                errorMessage = nil
+                logAuth("changeEmail needsRecentLogin")
+                return .needsRecentLogin
+            }
+            let message = AuthAppError.userMessage(for: error)
+            errorMessage = message
+            logAuth("changeEmail failed message=\(message)")
+            return .failure(message)
+        }
+    }
+}
+
 // MARK: - Password reset API
 
 extension AuthViewModel {
-    
+
     /// Result for password reset action.
     enum PasswordResetResult {
         case sent(email: String)
         case unavailable
         case failure(String)
     }
-    
+
     /// Sends a password reset email for the signed in account.
     func sendPasswordResetForCurrentUser() async -> PasswordResetResult {
         if ProcessInfo.processInfo.isPreview { return .failure("Unavailable in previews") }
         guard let service, currentUID != nil else { return .failure("No current user") }
         guard service.canSendPasswordReset else { return .unavailable }
-        
+
         isAuthenticating = true
         defer { isAuthenticating = false }
-        
+
         do {
             let email = try await service.sendPasswordResetToCurrentUserEmail()
             errorMessage = nil
+            logAuth("passwordReset sent email=\(maskedEmail(email))")
             return .sent(email: email)
         } catch {
             let message = AuthAppError.userMessage(for: error)
             errorMessage = message
+            logAuth("passwordReset failed message=\(message)")
             return .failure(message)
         }
     }
@@ -145,23 +190,23 @@ extension AuthViewModel {
 // MARK: - Deletion API
 
 extension AuthViewModel {
-    
+
     /// Result for delete account action.
     enum DeleteAccountResult {
         case success
         case needsRecentLogin
         case failure(String)
     }
-    
+
     func deleteCurrentAccount() async -> DeleteAccountResult {
         if ProcessInfo.processInfo.isPreview { return .failure("Unavailable in previews") }
         guard let service = self.service, currentUID != nil else {
             return .failure("No current user")
         }
-        
+
         isAuthenticating = true
         defer { isAuthenticating = false }
-        
+
         do {
             let result = try await service.deleteCurrentAccountWithDataCleanup()
             switch result {
@@ -192,7 +237,7 @@ extension AuthViewModel {
         }
         return service?.authProviderDescription ?? "Signed out"
     }
-    
+
     /// Email shown on the account screen.
     var currentUserEmail: String? {
         if ProcessInfo.processInfo.isPreview {
@@ -200,10 +245,35 @@ extension AuthViewModel {
         }
         return service?.currentUserEmail
     }
-    
+
     /// True when this account supports password reset emails.
     var canSendPasswordReset: Bool {
         if ProcessInfo.processInfo.isPreview { return currentUID != nil }
         return service?.canSendPasswordReset ?? false
+    }
+
+    /// True when this account supports email change.
+    var canChangeEmail: Bool {
+        if ProcessInfo.processInfo.isPreview { return currentUID != nil }
+        return service?.canChangeEmail ?? false
+    }
+}
+
+// MARK: - Debug logging
+
+private extension AuthViewModel {
+    func maskedEmail(_ email: String) -> String {
+        let trimmed = email.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let atIndex = trimmed.firstIndex(of: "@") else { return "***" }
+        let name = String(trimmed[..<atIndex])
+        let domain = String(trimmed[trimmed.index(after: atIndex)...])
+        let first = name.first.map(String.init) ?? ""
+        return "\(first)***@\(domain)"
+    }
+
+    func logAuth(_ message: String) {
+#if DEBUG
+        print("[App][Auth][ViewModel] \(message)")
+#endif
     }
 }

--- a/CineMate/CineMate/Features/Account/Auth/ViewModels/LoginViewModel.swift
+++ b/CineMate/CineMate/Features/Account/Auth/ViewModels/LoginViewModel.swift
@@ -82,15 +82,21 @@ final class LoginViewModel: ObservableObject {
         hasTriedSubmit = true
         email = AuthValidator.sanitizedEmail(from: email)
         guard canSubmit, let service else { return }
+        logAuth("login start email=\(maskedEmail(email))")
 
         startAction(.emailPassword)
         defer { finishAction() }
         do {
             let uid = try await service.signIn(email: email, password: password)
             appError = nil
+            logAuth("login success uid=\(uid.prefix(8)) email=\(maskedEmail(email))")
             onSuccess(uid)
         } catch {
-            appError = AuthAppError.mapToAppError(error)
+            let mapped = AuthAppError.mapToAppError(error)
+            appError = mapped
+            logAuth(
+                "login failed email=\(maskedEmail(email)) mapped=\(mapped.errorDescription ?? "unknown") \(describe(error: error))"
+            )
         }
     }
 
@@ -141,6 +147,26 @@ final class LoginViewModel: ObservableObject {
     private func finishAction() {
         activeAction = nil
         isAuthenticating = false
+    }
+
+    private func describe(error: Error) -> String {
+        let nsError = error as NSError
+        return "domain=\(nsError.domain) code=\(nsError.code) message=\(nsError.localizedDescription)"
+    }
+
+    private func maskedEmail(_ email: String) -> String {
+        let trimmed = email.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let atIndex = trimmed.firstIndex(of: "@") else { return "***" }
+        let name = String(trimmed[..<atIndex])
+        let domain = String(trimmed[trimmed.index(after: atIndex)...])
+        let first = name.first.map(String.init) ?? ""
+        return "\(first)***@\(domain)"
+    }
+
+    private func logAuth(_ message: String) {
+#if DEBUG
+        print("[App][Auth][LoginVM] \(message)")
+#endif
     }
 }
 

--- a/CineMate/CineMate/Features/Account/Auth/Views/AccountView.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Views/AccountView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-/// Account screen with session info, provider info, actions, and danger zone.
+/// Account screen with session info and account actions.
 struct AccountView: View {
     @ObservedObject private var authViewModel: AuthViewModel
     @EnvironmentObject private var navigator: AppNavigator
@@ -61,6 +61,35 @@ struct AccountView: View {
                             .buttonStyle(.borderedProminent)
                             .tint(.appPrimaryAction)
                             .disabled(authViewModel.isAuthenticating)
+                        }
+                    }
+
+                    if !authViewModel.isGuest {
+                        Section("Security") {
+                            if authViewModel.canSendPasswordReset {
+                                if let email = authViewModel.currentUserEmail {
+                                    Text("Reset links are sent to \(email).")
+                                        .foregroundStyle(Color.appTextSecondary)
+                                }
+
+                                Button("Change password") {
+                                    Task {
+                                        switch await authViewModel.sendPasswordResetForCurrentUser() {
+                                        case .sent(let email):
+                                            toastCenter.show("Password reset link sent to \(email)")
+                                        case .unavailable:
+                                            toastCenter.show("Password reset is only available for email sign-in")
+                                        case .failure(let message):
+                                            toastCenter.show(message)
+                                        }
+                                    }
+                                }
+                                .buttonStyle(.bordered)
+                                .disabled(authViewModel.isAuthenticating)
+                            } else {
+                                Text("Password reset is only available for email accounts.")
+                                    .foregroundStyle(Color.appTextSecondary)
+                            }
                         }
                     }
 

--- a/CineMate/CineMate/Features/Account/Auth/Views/AccountView.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Views/AccountView.swift
@@ -12,13 +12,14 @@ struct AccountView: View {
     @ObservedObject private var authViewModel: AuthViewModel
     @EnvironmentObject private var navigator: AppNavigator
     @EnvironmentObject private var toastCenter: ToastCenter
+    @Environment(\.scenePhase) private var scenePhase
     @State private var isShowingChangeEmailAlert = false
     @State private var pendingNewEmail = ""
-    
+
     init(viewModel: AuthViewModel) {
         self._authViewModel = ObservedObject(wrappedValue: viewModel)
     }
-    
+
     var body: some View {
         ZStack {
             Form {
@@ -40,7 +41,7 @@ struct AccountView: View {
                         }
                     }
                 }
-                
+
                 if authViewModel.isSignedIn {
                     Section("Provider") {
                         HStack {
@@ -51,12 +52,12 @@ struct AccountView: View {
                                 .multilineTextAlignment(.trailing)
                         }
                     }
-                    
+
                     if authViewModel.isGuest {
                         Section("Guest account") {
                             Text("Create an account to unlock Discover and Search.")
                                 .foregroundStyle(Color.appTextSecondary)
-                            
+
                             Button("Create Account") {
                                 navigator.goToCreateAccount()
                             }
@@ -65,7 +66,7 @@ struct AccountView: View {
                             .disabled(authViewModel.isAuthenticating)
                         }
                     }
-                    
+
                     if !authViewModel.isGuest {
                         Section("Email") {
                             if let email = authViewModel.currentUserEmail {
@@ -77,7 +78,7 @@ struct AccountView: View {
                                         .multilineTextAlignment(.trailing)
                                 }
                             }
-                            
+
                             if authViewModel.canChangeEmail {
                                 Button("Change email") {
                                     pendingNewEmail = authViewModel.currentUserEmail ?? ""
@@ -91,7 +92,7 @@ struct AccountView: View {
                             }
                         }
                     }
-                    
+
                     if !authViewModel.isGuest {
                         Section("Security") {
                             if authViewModel.canSendPasswordReset {
@@ -99,7 +100,7 @@ struct AccountView: View {
                                     Text("Reset links are sent to \(email).")
                                         .foregroundStyle(Color.appTextSecondary)
                                 }
-                                
+
                                 Button("Change password") {
                                     Task {
                                         switch await authViewModel.sendPasswordResetForCurrentUser() {
@@ -120,7 +121,7 @@ struct AccountView: View {
                             }
                         }
                     }
-                    
+
                     Section("Actions") {
                         Button(authViewModel.isGuest ? "End guest session" : "Sign out") {
                             Task {
@@ -135,7 +136,7 @@ struct AccountView: View {
                         .tint(.appPrimaryAction)
                         .disabled(authViewModel.isAuthenticating)
                     }
-                    
+
                     if !authViewModel.isGuest {
                         AccountDangerZoneView(
                             authViewModel: authViewModel,
@@ -156,6 +157,9 @@ struct AccountView: View {
             .disabled(authViewModel.isAuthenticating)
             .alert("Change email", isPresented: $isShowingChangeEmailAlert) {
                 TextField("New email", text: $pendingNewEmail)
+                    .keyboardType(.emailAddress)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled(true)
                 Button("Cancel", role: .cancel) {}
                 Button("Send verification link") {
                     Task { await sendChangeEmailVerification() }
@@ -164,7 +168,13 @@ struct AccountView: View {
             } message: {
                 Text("We will send a verification link to your new email address.")
             }
-            
+            .onChange(of: pendingNewEmail) { _, newValue in
+                let sanitized = sanitizeChangeEmailInput(newValue)
+                if sanitized != newValue {
+                    pendingNewEmail = sanitized
+                }
+            }
+
             if let error = authViewModel.errorMessage {
                 ErrorMessageView(
                     title: "Authentication Error",
@@ -176,8 +186,12 @@ struct AccountView: View {
             }
         }
         .animation(.default, value: authViewModel.errorMessage != nil)
+        .onChange(of: scenePhase) { _, newPhase in
+            guard newPhase == .active else { return }
+            Task { await authViewModel.refreshCurrentUserFromServer() }
+        }
     }
-    
+
     @MainActor
     private func sendChangeEmailVerification() async {
         switch await authViewModel.sendChangeEmailVerification(to: pendingNewEmail) {
@@ -190,6 +204,10 @@ struct AccountView: View {
         case .failure(let message):
             toastCenter.show(message)
         }
+    }
+
+    private func sanitizeChangeEmailInput(_ value: String) -> String {
+        AuthValidator.sanitizedEmail(from: value).filter(\.isASCII)
     }
 }
 

--- a/CineMate/CineMate/Features/Account/Auth/Views/AccountView.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Views/AccountView.swift
@@ -13,13 +13,12 @@ struct AccountView: View {
     @EnvironmentObject private var navigator: AppNavigator
     @EnvironmentObject private var toastCenter: ToastCenter
     @Environment(\.scenePhase) private var scenePhase
-    @State private var isShowingChangeEmailAlert = false
-    @State private var pendingNewEmail = ""
-
+    @State private var isShowingChangeEmailSheet = false
+    
     init(viewModel: AuthViewModel) {
         self._authViewModel = ObservedObject(wrappedValue: viewModel)
     }
-
+    
     var body: some View {
         ZStack {
             Form {
@@ -41,7 +40,7 @@ struct AccountView: View {
                         }
                     }
                 }
-
+                
                 if authViewModel.isSignedIn {
                     Section("Provider") {
                         HStack {
@@ -52,12 +51,12 @@ struct AccountView: View {
                                 .multilineTextAlignment(.trailing)
                         }
                     }
-
+                    
                     if authViewModel.isGuest {
                         Section("Guest account") {
                             Text("Create an account to unlock Discover and Search.")
                                 .foregroundStyle(Color.appTextSecondary)
-
+                            
                             Button("Create Account") {
                                 navigator.goToCreateAccount()
                             }
@@ -66,7 +65,7 @@ struct AccountView: View {
                             .disabled(authViewModel.isAuthenticating)
                         }
                     }
-
+                    
                     if !authViewModel.isGuest {
                         Section("Email") {
                             if let email = authViewModel.currentUserEmail {
@@ -78,11 +77,10 @@ struct AccountView: View {
                                         .multilineTextAlignment(.trailing)
                                 }
                             }
-
+                            
                             if authViewModel.canChangeEmail {
                                 Button("Change email") {
-                                    pendingNewEmail = authViewModel.currentUserEmail ?? ""
-                                    isShowingChangeEmailAlert = true
+                                    isShowingChangeEmailSheet = true
                                 }
                                 .buttonStyle(.bordered)
                                 .disabled(authViewModel.isAuthenticating)
@@ -92,7 +90,7 @@ struct AccountView: View {
                             }
                         }
                     }
-
+                    
                     if !authViewModel.isGuest {
                         Section("Security") {
                             if authViewModel.canSendPasswordReset {
@@ -100,7 +98,7 @@ struct AccountView: View {
                                     Text("Reset links are sent to \(email).")
                                         .foregroundStyle(Color.appTextSecondary)
                                 }
-
+                                
                                 Button("Change password") {
                                     Task {
                                         switch await authViewModel.sendPasswordResetForCurrentUser() {
@@ -121,7 +119,7 @@ struct AccountView: View {
                             }
                         }
                     }
-
+                    
                     Section("Actions") {
                         Button(authViewModel.isGuest ? "End guest session" : "Sign out") {
                             Task {
@@ -136,7 +134,7 @@ struct AccountView: View {
                         .tint(.appPrimaryAction)
                         .disabled(authViewModel.isAuthenticating)
                     }
-
+                    
                     if !authViewModel.isGuest {
                         AccountDangerZoneView(
                             authViewModel: authViewModel,
@@ -155,26 +153,18 @@ struct AccountView: View {
             }
             .navigationTitle("Account")
             .disabled(authViewModel.isAuthenticating)
-            .alert("Change email", isPresented: $isShowingChangeEmailAlert) {
-                TextField("New email", text: $pendingNewEmail)
-                    .keyboardType(.emailAddress)
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled(true)
-                Button("Cancel", role: .cancel) {}
-                Button("Send verification link") {
-                    Task { await sendChangeEmailVerification() }
-                }
-                .disabled(!AuthValidator.isValidEmail(pendingNewEmail))
-            } message: {
-                Text("We will send a verification link to your new email address.")
+            .sheet(isPresented: $isShowingChangeEmailSheet) {
+                ChangeEmailSheet(
+                    currentEmail: authViewModel.currentUserEmail,
+                    onSubmit: { newEmail in
+                        await authViewModel.sendChangeEmailVerification(to: newEmail)
+                    },
+                    onResult: { result in
+                        handleChangeEmailResult(result)
+                    }
+                )
             }
-            .onChange(of: pendingNewEmail) { _, newValue in
-                let sanitized = sanitizeChangeEmailInput(newValue)
-                if sanitized != newValue {
-                    pendingNewEmail = sanitized
-                }
-            }
-
+            
             if let error = authViewModel.errorMessage {
                 ErrorMessageView(
                     title: "Authentication Error",
@@ -191,23 +181,20 @@ struct AccountView: View {
             Task { await authViewModel.refreshCurrentUserFromServer() }
         }
     }
-
-    @MainActor
-    private func sendChangeEmailVerification() async {
-        switch await authViewModel.sendChangeEmailVerification(to: pendingNewEmail) {
+    
+    private func handleChangeEmailResult(_ result: AuthViewModel.ChangeEmailResult) {
+        switch result {
         case .verificationSent(let email):
             toastCenter.show("Verification link sent to \(email)")
         case .unavailable:
             toastCenter.show("Email change is only available for email sign-in")
+        case .cooldown(let seconds):
+            toastCenter.show("Please wait \(seconds) seconds before sending another link")
         case .needsRecentLogin:
             toastCenter.show("Please sign in again to change your email")
         case .failure(let message):
             toastCenter.show(message)
         }
-    }
-
-    private func sanitizeChangeEmailInput(_ value: String) -> String {
-        AuthValidator.sanitizedEmail(from: value).filter(\.isASCII)
     }
 }
 

--- a/CineMate/CineMate/Features/Account/Auth/Views/AccountView.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Views/AccountView.swift
@@ -12,11 +12,13 @@ struct AccountView: View {
     @ObservedObject private var authViewModel: AuthViewModel
     @EnvironmentObject private var navigator: AppNavigator
     @EnvironmentObject private var toastCenter: ToastCenter
-
+    @State private var isShowingChangeEmailAlert = false
+    @State private var pendingNewEmail = ""
+    
     init(viewModel: AuthViewModel) {
         self._authViewModel = ObservedObject(wrappedValue: viewModel)
     }
-
+    
     var body: some View {
         ZStack {
             Form {
@@ -38,7 +40,7 @@ struct AccountView: View {
                         }
                     }
                 }
-
+                
                 if authViewModel.isSignedIn {
                     Section("Provider") {
                         HStack {
@@ -49,12 +51,12 @@ struct AccountView: View {
                                 .multilineTextAlignment(.trailing)
                         }
                     }
-
+                    
                     if authViewModel.isGuest {
                         Section("Guest account") {
                             Text("Create an account to unlock Discover and Search.")
                                 .foregroundStyle(Color.appTextSecondary)
-
+                            
                             Button("Create Account") {
                                 navigator.goToCreateAccount()
                             }
@@ -63,7 +65,33 @@ struct AccountView: View {
                             .disabled(authViewModel.isAuthenticating)
                         }
                     }
-
+                    
+                    if !authViewModel.isGuest {
+                        Section("Email") {
+                            if let email = authViewModel.currentUserEmail {
+                                HStack {
+                                    Text("Current email")
+                                    Spacer()
+                                    Text(email)
+                                        .foregroundStyle(Color.appTextSecondary)
+                                        .multilineTextAlignment(.trailing)
+                                }
+                            }
+                            
+                            if authViewModel.canChangeEmail {
+                                Button("Change email") {
+                                    pendingNewEmail = authViewModel.currentUserEmail ?? ""
+                                    isShowingChangeEmailAlert = true
+                                }
+                                .buttonStyle(.bordered)
+                                .disabled(authViewModel.isAuthenticating)
+                            } else {
+                                Text("Email change is only available for email accounts.")
+                                    .foregroundStyle(Color.appTextSecondary)
+                            }
+                        }
+                    }
+                    
                     if !authViewModel.isGuest {
                         Section("Security") {
                             if authViewModel.canSendPasswordReset {
@@ -71,7 +99,7 @@ struct AccountView: View {
                                     Text("Reset links are sent to \(email).")
                                         .foregroundStyle(Color.appTextSecondary)
                                 }
-
+                                
                                 Button("Change password") {
                                     Task {
                                         switch await authViewModel.sendPasswordResetForCurrentUser() {
@@ -92,7 +120,7 @@ struct AccountView: View {
                             }
                         }
                     }
-
+                    
                     Section("Actions") {
                         Button(authViewModel.isGuest ? "End guest session" : "Sign out") {
                             Task {
@@ -107,7 +135,7 @@ struct AccountView: View {
                         .tint(.appPrimaryAction)
                         .disabled(authViewModel.isAuthenticating)
                     }
-
+                    
                     if !authViewModel.isGuest {
                         AccountDangerZoneView(
                             authViewModel: authViewModel,
@@ -126,7 +154,17 @@ struct AccountView: View {
             }
             .navigationTitle("Account")
             .disabled(authViewModel.isAuthenticating)
-
+            .alert("Change email", isPresented: $isShowingChangeEmailAlert) {
+                TextField("New email", text: $pendingNewEmail)
+                Button("Cancel", role: .cancel) {}
+                Button("Send verification link") {
+                    Task { await sendChangeEmailVerification() }
+                }
+                .disabled(!AuthValidator.isValidEmail(pendingNewEmail))
+            } message: {
+                Text("We will send a verification link to your new email address.")
+            }
+            
             if let error = authViewModel.errorMessage {
                 ErrorMessageView(
                     title: "Authentication Error",
@@ -138,6 +176,20 @@ struct AccountView: View {
             }
         }
         .animation(.default, value: authViewModel.errorMessage != nil)
+    }
+    
+    @MainActor
+    private func sendChangeEmailVerification() async {
+        switch await authViewModel.sendChangeEmailVerification(to: pendingNewEmail) {
+        case .verificationSent(let email):
+            toastCenter.show("Verification link sent to \(email)")
+        case .unavailable:
+            toastCenter.show("Email change is only available for email sign-in")
+        case .needsRecentLogin:
+            toastCenter.show("Please sign in again to change your email")
+        case .failure(let message):
+            toastCenter.show(message)
+        }
     }
 }
 

--- a/CineMate/CineMate/Features/Account/Auth/Views/ChangeEmailSheet.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Views/ChangeEmailSheet.swift
@@ -27,8 +27,13 @@ struct ChangeEmailSheet: View {
         !confirmEmail.isEmpty && confirmEmail == newEmail
     }
 
+    private var isSameAsCurrentEmail: Bool {
+        guard let currentEmail else { return false }
+        return AuthValidator.sanitizedEmail(from: currentEmail) == AuthValidator.sanitizedEmail(from: newEmail)
+    }
+
     private var canSubmit: Bool {
-        isNewEmailValid && isConfirmMatch && !isSubmitting && cooldownRemainingSeconds == 0
+        isNewEmailValid && isConfirmMatch && !isSameAsCurrentEmail && !isSubmitting && cooldownRemainingSeconds == 0
     }
 
     var body: some View {
@@ -57,6 +62,11 @@ struct ChangeEmailSheet: View {
 
                     if (hasTriedSubmit || !newEmail.isEmpty) && !isNewEmailValid {
                         Text(AuthValidator.Message.invalidEmail)
+                            .foregroundStyle(.red)
+                    }
+
+                    if (hasTriedSubmit || !newEmail.isEmpty) && isSameAsCurrentEmail {
+                        Text("New email must be different from current email")
                             .foregroundStyle(.red)
                     }
 

--- a/CineMate/CineMate/Features/Account/Auth/Views/ChangeEmailSheet.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Views/ChangeEmailSheet.swift
@@ -1,0 +1,135 @@
+//
+//  ChangeEmailSheet.swift
+//  CineMate
+//
+//  Created by Nicholas Samuelsson Jeria on 2026-04-09.
+//
+
+import SwiftUI
+
+struct ChangeEmailSheet: View {
+    let currentEmail: String?
+    let onSubmit: (String) async -> AuthViewModel.ChangeEmailResult
+    let onResult: (AuthViewModel.ChangeEmailResult) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var newEmail = ""
+    @State private var confirmEmail = ""
+    @State private var hasTriedSubmit = false
+    @State private var isSubmitting = false
+    @State private var cooldownRemainingSeconds = 0
+
+    private var isNewEmailValid: Bool {
+        AuthValidator.isValidEmail(newEmail)
+    }
+
+    private var isConfirmMatch: Bool {
+        !confirmEmail.isEmpty && confirmEmail == newEmail
+    }
+
+    private var canSubmit: Bool {
+        isNewEmailValid && isConfirmMatch && !isSubmitting && cooldownRemainingSeconds == 0
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                if let currentEmail {
+                    Section("Current email") {
+                        Text(currentEmail)
+                            .foregroundStyle(Color.appTextSecondary)
+                            .textSelection(.enabled)
+                    }
+                }
+
+                Section("New email") {
+                    TextField("New email", text: $newEmail)
+                        .keyboardType(.emailAddress)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled(true)
+                        .disabled(isSubmitting)
+
+                    TextField("Confirm new email", text: $confirmEmail)
+                        .keyboardType(.emailAddress)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled(true)
+                        .disabled(isSubmitting)
+
+                    if (hasTriedSubmit || !newEmail.isEmpty) && !isNewEmailValid {
+                        Text(AuthValidator.Message.invalidEmail)
+                            .foregroundStyle(.red)
+                    }
+
+                    if (hasTriedSubmit || !confirmEmail.isEmpty) && !isConfirmMatch {
+                        Text("Emails do not match")
+                            .foregroundStyle(.red)
+                    }
+                }
+
+                Section {
+                    Button("Send verification link") {
+                        Task { await submit() }
+                    }
+                    .disabled(!canSubmit)
+                } footer: {
+                    if cooldownRemainingSeconds > 0 {
+                        Text("Please wait \(cooldownRemainingSeconds) seconds before sending another link.")
+                    } else {
+                        Text("We send the verification link to your new email address.")
+                    }
+                }
+            }
+            .navigationTitle("Change Email")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .disabled(isSubmitting)
+                }
+            }
+            .onChange(of: newEmail) { _, newValue in
+                let sanitized = sanitizeEmailInput(newValue)
+                if sanitized != newValue {
+                    newEmail = sanitized
+                }
+            }
+            .onChange(of: confirmEmail) { _, newValue in
+                let sanitized = sanitizeEmailInput(newValue)
+                if sanitized != newValue {
+                    confirmEmail = sanitized
+                }
+            }
+            .onReceive(Timer.publish(every: 1, on: .main, in: .common).autoconnect()) { _ in
+                guard cooldownRemainingSeconds > 0 else { return }
+                cooldownRemainingSeconds -= 1
+            }
+        }
+    }
+
+    @MainActor
+    private func submit() async {
+        hasTriedSubmit = true
+        guard canSubmit else { return }
+
+        isSubmitting = true
+        defer { isSubmitting = false }
+
+        let result = await onSubmit(newEmail)
+        onResult(result)
+        switch result {
+        case .verificationSent:
+            dismiss()
+        case .cooldown(let seconds):
+            startCooldown(seconds: seconds)
+        default:
+            break
+        }
+    }
+
+    private func sanitizeEmailInput(_ value: String) -> String {
+        AuthValidator.sanitizedEmail(from: value).filter(\.isASCII)
+    }
+
+    private func startCooldown(seconds: Int) {
+        cooldownRemainingSeconds = max(seconds, 1)
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds password reset and email change support to the account flow.

## What changed
- added password reset support for signed-in email accounts
- added email change verification support in the auth service
- added account view actions for changing password and email
- added a dedicated `ChangeEmailSheet` for email update flow
- added cooldown handling for repeated email change requests
- added input validation for invalid, matching, and unchanged emails
- refreshed auth user data when the app becomes active
- improved auth error mapping for clearer UI messages
- added debug auth logging for sign-in and account actions
- updated the Xcode project to include the new sheet file
- raised the iOS deployment target from 17.4 to 17.6

## Notes
- password reset and email change are only available for email sign-in accounts
- email change now uses verification before updating the address
- repeated email change requests are rate-limited in the UI