### PR TITLE
feat: sanitize auth input and search text

### DIFF
--- a/CineMate/CineMate/Core/Firebase/Auth/Validation/AuthValidator.swift
+++ b/CineMate/CineMate/Core/Firebase/Auth/Validation/AuthValidator.swift
@@ -7,18 +7,17 @@
 
 import Foundation
 
-/// Shared auth input validator.
-/// This keeps sanitize and validation rules in one place.
+/// Shared sanitize and validation rules for auth input.
 enum AuthValidator {
-    
+
     // MARK: - Policy
-    
-    /// Password rules.
+
+    /// Password limits used by auth forms.
     enum Policy {
-        /// Minimum allowed password length
+        /// Minimum password length.
         static let minLength = 12
     }
-    
+
     enum Message {
         static let invalidEmail = "Enter a valid email address"
         static let invalidPassword = "Password must be at least \(Policy.minLength) chars and include A-Z, a-z, 0-9"
@@ -26,63 +25,65 @@ enum AuthValidator {
         static let passwordMismatch = "Passwords don't match"
         static let termsRequired = "You must accept the terms to continue"
     }
-    
+
+    // MARK: - Character policy
+    private static let allowedEmailCharacters = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyz0123456789@._+-")
+
     // MARK: - Sanitizers
-    
-    /// Removes all whitespace characters.
-    static func removeAllWhitespace(from text: String) -> String {
-        text.filter { !$0.isWhitespace }
-    }
-    
-    /// Trims and lowercases email input.
+
+    /// Lowercases input and keeps only supported email characters.
     static func sanitizedEmail(from email: String) -> String {
-        removeAllWhitespace(from: email)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased()
+        let lowered = email.lowercased()
+        let filteredScalars = lowered.unicodeScalars.filter { scalar in
+            allowedEmailCharacters.contains(scalar)
+        }
+        return String(String.UnicodeScalarView(filteredScalars))
     }
-    
-    /// Trims password input and removes whitespace.
+
+    /// Trims edge whitespace and keeps printable ASCII only.
+    /// This removes emoji and smart punctuation.
     static func sanitizedPassword(from password: String) -> String {
-        removeAllWhitespace(from: password)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = password.trimmingCharacters(in: .whitespacesAndNewlines)
+        let filteredScalars = trimmed.unicodeScalars.filter { scalar in
+            scalar.isASCII && (0x20...0x7E).contains(scalar.value)
+        }
+        return String(String.UnicodeScalarView(filteredScalars))
     }
-    
-    /// Sanitizes password and confirm password together.
+
+    /// Sanitizes password fields with the same rules.
     static func sanitizedPasswordPair(password: String, confirmPassword: String) -> (password: String, confirmPassword: String) {
         (
             password: sanitizedPassword(from: password),
             confirmPassword: sanitizedPassword(from: confirmPassword)
         )
     }
-    
-    // MARK: - Validators (Swift Regex)
-    
-    /// Simple email check for UI forms.
+
+    // MARK: - Validators
+
+    /// Basic email format check for UI forms.
     static func isValidEmail(_ email: String) -> Bool {
         let cleaned = sanitizedEmail(from: email)
         return !cleaned.isEmpty
-        && cleaned.wholeMatch(of: /[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,64}/) != nil
+        && cleaned.wholeMatch(of: /[a-z0-9._+-]+@[a-z0-9.-]+\.[a-z]{2,64}/) != nil
     }
-    
-    /// Password policy used for account creation.
-    /// Requires one digit, one lowercase and one uppercase character.
-    /// Length must be at least `Policy.minLength`.
+
+    /// Password check for account creation.
+    /// Requires one digit, one lowercase, one uppercase, and min length.
     static func isValidPassword(_ password: String) -> Bool {
         let cleaned = sanitizedPassword(from: password)
         let pattern = #"^(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{\#(Policy.minLength),}$"#
         return !cleaned.isEmpty && cleaned.wholeMatch(of: try! Regex(pattern)) != nil
     }
 
-    /// Login should only require a present password.
-    /// Strength checks belong to account creation/reset flows.
+    /// Login only checks that password is not empty after sanitize.
     static func isValidLoginPassword(_ password: String) -> Bool {
         !sanitizedPassword(from: password).isEmpty
     }
-    
+
     static func emailHelperText(email: String, hasTriedSubmit: Bool) -> String? {
         hasTriedSubmit && !isValidEmail(email) ? Message.invalidEmail : nil
     }
-    
+
     static func passwordHelperText(password: String, hasTriedSubmit: Bool) -> String? {
         hasTriedSubmit && !isValidPassword(password) ? Message.invalidPassword : nil
     }
@@ -90,7 +91,7 @@ enum AuthValidator {
     static func loginPasswordHelperText(password: String, hasTriedSubmit: Bool) -> String? {
         hasTriedSubmit && !isValidLoginPassword(password) ? Message.missingPassword : nil
     }
-    
+
     static func confirmPasswordHelperText(
         password: String,
         confirmPassword: String,
@@ -100,7 +101,7 @@ enum AuthValidator {
         let isMatch = !sanitized.password.isEmpty && sanitized.password == sanitized.confirmPassword
         return (hasTriedSubmit || !sanitized.confirmPassword.isEmpty) && !isMatch ? Message.passwordMismatch : nil
     }
-    
+
     static func termsHelperText(acceptedTerms: Bool, hasTriedSubmit: Bool) -> String? {
         !acceptedTerms && hasTriedSubmit ? Message.termsRequired : nil
     }

--- a/CineMate/CineMate/Features/Account/Auth/Components/AuthPasswordField.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Components/AuthPasswordField.swift
@@ -39,13 +39,13 @@ struct AuthPasswordField: View {
     }
 }
 
-// MARK: - Internals (private helpers)
+// MARK: - Helpers
 private extension AuthPasswordField {
     var hasText: Bool { !text.isEmpty }
 
     var revealIconName: String { isRevealed ? "eye.slash.fill" : "eye.fill" }
 
-    /// Trailing icons (clear + reveal) when enabled and non-empty.
+    /// Shows clear and reveal icons only when text exists.
     var trailingIcons: [TrailingIcon] {
         guard hasText && !isDisabled else { return [] }
         return [clearIcon, revealIcon]
@@ -72,7 +72,7 @@ private extension AuthPasswordField {
         }
     }
 
-    /// Chooses between `TextField` and `SecureField` based on `isRevealed`.
+    /// Uses TextField when revealed and SecureField when hidden.
     @ViewBuilder
     var passwordField: some View {
         if isRevealed {
@@ -83,20 +83,21 @@ private extension AuthPasswordField {
     }
 }
 
-// MARK: - Content type / keyboard policy
+// MARK: - Input traits
 private extension View {
-    /// Applies contentType/keyboard for the given `AuthPasswordField.Mode`.
+    /// Applies text traits for each password mode.
     @ViewBuilder
     func applyContentType(mode: AuthPasswordField.Mode) -> some View {
+        let baseInputPolicy = self
+            .keyboardType(.asciiCapable)
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled(true)
+
         switch mode {
         case .login:
-            self.textContentType(.password)
+            baseInputPolicy.textContentType(.password)
         case .create:
-            self
-                .textContentType(nil)
-                .keyboardType(.asciiCapable)
-                .textInputAutocapitalization(.never)
-                .autocorrectionDisabled(true)
+            baseInputPolicy.textContentType(nil)
         }
     }
 }

--- a/CineMate/CineMate/Features/Account/Auth/ViewModels/LoginViewModel.swift
+++ b/CineMate/CineMate/Features/Account/Auth/ViewModels/LoginViewModel.swift
@@ -8,8 +8,7 @@
 import Foundation
 import UIKit
 
-/// View model for LoginView.
-/// Handles login form state, loading, and errors.
+/// State and actions for the login screen.
 @MainActor
 final class LoginViewModel: ObservableObject {
 
@@ -29,22 +28,22 @@ final class LoginViewModel: ObservableObject {
         }
     }
 
-    // MARK: - Form state (bound to UI)
+    // MARK: - Form state
     @Published var email = ""
     @Published var password = ""
 
-    // MARK: - UI state (loading/errors)
+    // MARK: - UI state
     @Published var isAuthenticating = false
     @Published private(set) var appError: AuthAppError?
     @Published var hasTriedSubmit = false
     @Published private(set) var activeAction: Action?
 
     // MARK: - Dependencies
-    private let service: FirebaseAuthService?          // nil in previews
-    private let googleClient: GoogleAuthClient         // defaults to live
-    private let onSuccess: (String) -> Void            // returns Firebase UID
+    private let service: FirebaseAuthService?
+    private let googleClient: GoogleAuthClient
+    private let onSuccess: (String) -> Void
 
-    // MARK: - Derived UI (helpers for the view)
+    // MARK: - Derived state
     var errorMessage: String? { appError?.errorDescription }
     var isEmailValid: Bool { AuthValidator.isValidEmail(email) }
     var isPasswordValid: Bool { AuthValidator.isValidLoginPassword(password) }
@@ -65,8 +64,7 @@ final class LoginViewModel: ObservableObject {
         self.onSuccess = onSuccess
     }
 
-    /// Preview init.
-    /// Uses preview client and no live service.
+    /// Preview initializer.
     init(previewEmail: String = "", previewIsAuthenticating: Bool = false, previewError: String? = nil) {
         self.service = nil
         self.googleClient = PreviewGoogleAuthClient()
@@ -81,6 +79,7 @@ final class LoginViewModel: ObservableObject {
     func login() async {
         hasTriedSubmit = true
         email = AuthValidator.sanitizedEmail(from: email)
+        password = AuthValidator.sanitizedPassword(from: password)
         guard canSubmit, let service else { return }
         logAuth("login start email=\(maskedEmail(email))")
 
@@ -174,8 +173,8 @@ final class LoginViewModel: ObservableObject {
 
 extension LoginViewModel {
 
-    /// Runs Google sign in flow.
-    /// User cancel does not show an error.
+    /// Starts Google sign in.
+    /// User cancel keeps the screen silent.
     func signInWithGoogle() async {
         guard let service else { return }
         guard let presenter = UIViewController.topMostViewController else {

--- a/CineMate/CineMate/Features/Account/Auth/Views/ChangeEmailSheet.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Views/ChangeEmailSheet.swift
@@ -49,12 +49,14 @@ struct ChangeEmailSheet: View {
 
                 Section("New email") {
                     TextField("New email", text: $newEmail)
+                        .textContentType(.emailAddress)
                         .keyboardType(.emailAddress)
                         .textInputAutocapitalization(.never)
                         .autocorrectionDisabled(true)
                         .disabled(isSubmitting)
 
                     TextField("Confirm new email", text: $confirmEmail)
+                        .textContentType(.emailAddress)
                         .keyboardType(.emailAddress)
                         .textInputAutocapitalization(.never)
                         .autocorrectionDisabled(true)
@@ -136,7 +138,7 @@ struct ChangeEmailSheet: View {
     }
 
     private func sanitizeEmailInput(_ value: String) -> String {
-        AuthValidator.sanitizedEmail(from: value).filter(\.isASCII)
+        AuthValidator.sanitizedEmail(from: value)
     }
 
     private func startCooldown(seconds: Int) {

--- a/CineMate/CineMate/Features/Search/Logic/SearchValidator.swift
+++ b/CineMate/CineMate/Features/Search/Logic/SearchValidator.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-/// Represents the outcome of a search query validation.
+/// Validation result for a search query.
 enum SearchValidationResult {
     case valid(trimmed: String)
     case empty
@@ -16,11 +16,32 @@ enum SearchValidationResult {
     case invalidCharacters
 }
 
-/// A utility for validating search queries before they are sent to the API.
+/// Rules for search input.
 struct SearchValidator {
-    /// Validates a given query string and returns a `SearchValidationResult`.
-    /// - Parameter query: The user input to validate.
-    /// - Returns: A validation result with either `.valid(trimmed:)` or a failure case.
+    static let minLength = 2
+    static let maxLength = 50
+
+    private static let allowedCharacterSet = CharacterSet.letters
+        .union(.decimalDigits)
+        .union(.whitespaces)
+        .union(CharacterSet(charactersIn: "-':&!?,."))
+
+    /// Cleans search text while typing.
+    /// Keeps allowed characters, removes leading spaces, and limits length.
+    static func sanitizedInput(_ input: String) -> String {
+        let filteredScalars = input.unicodeScalars.filter { scalar in
+            allowedCharacterSet.contains(scalar)
+        }
+        let filtered = String(String.UnicodeScalarView(filteredScalars))
+        let withoutLeadingSpaces = filtered.replacingOccurrences(
+            of: #"^\s+"#,
+            with: "",
+            options: .regularExpression
+        )
+        return String(withoutLeadingSpaces.prefix(maxLength))
+    }
+
+    /// Validates query text used for search requests.
     static func validate(_ query: String) -> SearchValidationResult {
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
 
@@ -30,18 +51,13 @@ struct SearchValidator {
 
         let normalized = normalizeWhitespaces(in: trimmed)
 
-        guard normalized.count >= 2 else {
-            return .tooShort(minLength: 2)
+        guard normalized.count >= minLength else {
+            return .tooShort(minLength: minLength)
         }
 
-        guard normalized.count <= 50 else {
-            return .tooLong(maxLength: 50)
+        guard normalized.count <= maxLength else {
+            return .tooLong(maxLength: maxLength)
         }
-
-        let allowedCharacterSet = CharacterSet.letters
-            .union(.decimalDigits)
-            .union(.whitespaces)
-            .union(CharacterSet(charactersIn: "-':&!?,."))
 
         if normalized.rangeOfCharacter(from: allowedCharacterSet.inverted) != nil {
             return .invalidCharacters

--- a/CineMate/CineMate/Features/Search/Views/SearchBarView.swift
+++ b/CineMate/CineMate/Features/Search/Views/SearchBarView.swift
@@ -21,11 +21,13 @@ struct SearchBarView: View {
                 text: $text
             )
             .textInputAutocapitalization(.never)
-            .disableAutocorrection(true)
+            .autocorrectionDisabled(true)
+            .submitLabel(.search)
             .disabled(isDisabled)
-            .onChange(of: text) {
-                if text.hasPrefix(" ") {
-                    text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            .onChange(of: text) { _, newValue in
+                let sanitized = SearchValidator.sanitizedInput(newValue)
+                if sanitized != newValue {
+                    text = sanitized
                 }
             }
 

--- a/CineMate/CineMateTests/SearchValidatorTests.swift
+++ b/CineMate/CineMateTests/SearchValidatorTests.swift
@@ -48,6 +48,17 @@ final class SearchValidatorTests: XCTestCase {
             XCTFail("Expected .invalidCharacters")
         }
     }
+
+    func testSanitizedInputRemovesLeadingSpacesAndEmoji() {
+        let sanitized = SearchValidator.sanitizedInput("   Star🙂 Wars")
+        XCTAssertEqual(sanitized, "Star Wars")
+    }
+
+    func testSanitizedInputCapsLength() {
+        let longQuery = String(repeating: "a", count: 80)
+        let sanitized = SearchValidator.sanitizedInput(longQuery)
+        XCTAssertEqual(sanitized.count, SearchValidator.maxLength)
+    }
 }
 
 final class AuthValidatorTests: XCTestCase {
@@ -59,7 +70,7 @@ final class AuthValidatorTests: XCTestCase {
     func testEmailValidationAllowsExpectedCharacters() {
         XCTAssertTrue(AuthValidator.isValidEmail("user_name-1+tag@example-domain.com"))
     }
-    
+
     func testSanitizedPasswordRemovesEmojiAndSmartQuotesAndTrimsEdges() {
         let sanitized = AuthValidator.sanitizedPassword(from: "  Abc🙂123“x”!  ")
         XCTAssertEqual(sanitized, "Abc123x!")

--- a/CineMate/CineMateTests/SearchValidatorTests.swift
+++ b/CineMate/CineMateTests/SearchValidatorTests.swift
@@ -49,3 +49,37 @@ final class SearchValidatorTests: XCTestCase {
         }
     }
 }
+
+final class AuthValidatorTests: XCTestCase {
+    func testSanitizedEmailLowercasesAndStripsDisallowedCharacters() {
+        let sanitized = AuthValidator.sanitizedEmail(from: " TeSt_+🙂Namn@Exämple.COM ")
+        XCTAssertEqual(sanitized, "test_+namn@exmple.com")
+    }
+
+    func testEmailValidationAllowsExpectedCharacters() {
+        XCTAssertTrue(AuthValidator.isValidEmail("user_name-1+tag@example-domain.com"))
+    }
+    
+    func testSanitizedPasswordRemovesEmojiAndSmartQuotesAndTrimsEdges() {
+        let sanitized = AuthValidator.sanitizedPassword(from: "  Abc🙂123“x”!  ")
+        XCTAssertEqual(sanitized, "Abc123x!")
+    }
+
+    func testSanitizedPasswordKeepsCommonAsciiSymbols() {
+        let sanitized = AuthValidator.sanitizedPassword(from: "Abc123!@#$%^&*()[]{}_-+=/?.,:;")
+        XCTAssertEqual(sanitized, "Abc123!@#$%^&*()[]{}_-+=/?.,:;")
+    }
+
+    func testLoginPasswordRejectsOnlyEmojiAndWhitespace() {
+        XCTAssertFalse(AuthValidator.isValidLoginPassword("🙂 \n\t"))
+    }
+
+    func testConfirmPasswordMatchingUsesSameInputRules() {
+        let helper = AuthValidator.confirmPasswordHelperText(
+            password: "  Pa🙂sswordA1!  ",
+            confirmPassword: "PasswordA1!",
+            hasTriedSubmit: true
+        )
+        XCTAssertNil(helper)
+    }
+}


### PR DESCRIPTION
## Summary
This PR improves input handling for auth and search.

## What changed
- sanitize email input to keep only supported characters and lowercase it
- sanitize password input to remove emoji, smart punctuation, and non ASCII characters
- sanitize login password before submit
- apply stricter keyboard and text input traits to password and email fields
- sanitize search text while typing, remove invalid characters, trim leading spaces, and cap max length
- add tests for auth input sanitizing and search input sanitizing
- add account support for password reset from the signed in user
- add account support for change email with validation, cooldown, and clearer result handling
- add a dedicated ChangeEmailSheet for the email update flow
- refresh account user data when the app becomes active again
- add clearer auth logging around login, password reset, and email change flows

## Notes
- keeps the validation rules centralized in AuthValidator and SearchValidator
- improves UX by blocking invalid input earlier instead of waiting until submit