### PR TITLE
fix(terms): enforce acceptance and add rules tests

### DIFF
--- a/CineMate/CineMate.xcodeproj/project.pbxproj
+++ b/CineMate/CineMate.xcodeproj/project.pbxproj
@@ -128,6 +128,9 @@
 		036E06B22E5B9BAB006BBA92 /* PreviewFactory+ResetPassword.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036E06B12E5B9BAB006BBA92 /* PreviewFactory+ResetPassword.swift */; };
 		036E06B42E5BA418006BBA92 /* ResetPasswordSheet+Previews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036E06B32E5BA418006BBA92 /* ResetPasswordSheet+Previews.swift */; };
 		0371433A2E7200F200A35E04 /* TermSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 037143392E7200F200A35E04 /* TermSheet.swift */; };
+		B1C2D3002FA1000100A1A1A1 /* TermsMarkdownParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3032FA1000100A1A1A1 /* TermsMarkdownParser.swift */; };
+		B1C2D3012FA1000100A1A1A1 /* TermsBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3042FA1000100A1A1A1 /* TermsBlockView.swift */; };
+		B1C2D3022FA1000100A1A1A1 /* TermsHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3052FA1000100A1A1A1 /* TermsHeader.swift */; };
 		03757F132E60F2A800C5C2C1 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03757F122E60F2A800C5C2C1 /* GoogleService-Info.plist */; };
 		0381F4D32DFA261400AC2ABB /* MovieGenresView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0381F4D22DFA261400AC2ABB /* MovieGenresView.swift */; };
 		0384BD6D2E11318D00790AA5 /* PersonLinksView+Previews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0384BD6C2E11318D00790AA5 /* PersonLinksView+Previews.swift */; };
@@ -394,6 +397,9 @@
 		036E06B12E5B9BAB006BBA92 /* PreviewFactory+ResetPassword.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PreviewFactory+ResetPassword.swift"; sourceTree = "<group>"; };
 		036E06B32E5BA418006BBA92 /* ResetPasswordSheet+Previews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ResetPasswordSheet+Previews.swift"; sourceTree = "<group>"; };
 		037143392E7200F200A35E04 /* TermSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermSheet.swift; sourceTree = "<group>"; };
+		B1C2D3032FA1000100A1A1A1 /* TermsMarkdownParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsMarkdownParser.swift; sourceTree = "<group>"; };
+		B1C2D3042FA1000100A1A1A1 /* TermsBlockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsBlockView.swift; sourceTree = "<group>"; };
+		B1C2D3052FA1000100A1A1A1 /* TermsHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsHeader.swift; sourceTree = "<group>"; };
 		03757F122E60F2A800C5C2C1 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		0381F4D22DFA261400AC2ABB /* MovieGenresView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieGenresView.swift; sourceTree = "<group>"; };
 		0384BD6C2E11318D00790AA5 /* PersonLinksView+Previews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersonLinksView+Previews.swift"; sourceTree = "<group>"; };
@@ -1069,6 +1075,9 @@
 			isa = PBXGroup;
 			children = (
 				037143392E7200F200A35E04 /* TermSheet.swift */,
+				B1C2D3052FA1000100A1A1A1 /* TermsHeader.swift */,
+				B1C2D3042FA1000100A1A1A1 /* TermsBlockView.swift */,
+				B1C2D3032FA1000100A1A1A1 /* TermsMarkdownParser.swift */,
 			);
 			path = Sheets;
 			sourceTree = "<group>";
@@ -1860,6 +1869,9 @@
 				03BAD6992E297F5B0035F1F5 /* CastMemberPreviewData.swift in Sources */,
 				03D8D2B42E09F1FF006A117D /* MovieListView+Previews.swift in Sources */,
 				0371433A2E7200F200A35E04 /* TermSheet.swift in Sources */,
+				B1C2D3022FA1000100A1A1A1 /* TermsHeader.swift in Sources */,
+				B1C2D3012FA1000100A1A1A1 /* TermsBlockView.swift in Sources */,
+				B1C2D3002FA1000100A1A1A1 /* TermsMarkdownParser.swift in Sources */,
 				033CAA0A2E6251D6009514D0 /* GoogleSignInBootstrap.swift in Sources */,
 				03E3557E2DF9C060001F1001 /* MovieCredits.swift in Sources */,
 				031F2E362E0DDFDE001E41B8 /* TMDBImageHelper.swift in Sources */,

--- a/CineMate/CineMate/Core/Firebase/Auth/Services/FirebaseAuthService.swift
+++ b/CineMate/CineMate/Core/Firebase/Auth/Services/FirebaseAuthService.swift
@@ -7,14 +7,28 @@
 
 import Foundation
 import FirebaseAuth
+import FirebaseFirestore
 import GoogleSignIn
 import UIKit
+
+/// Snapshot of stored terms acceptance for one user.
+struct TermsAcceptanceSnapshot: Equatable {
+    let termsVersion: String
+    let acceptedAt: Date?
+    let appVersion: String?
+}
 
 /// Auth service for sign in and account actions.
 /// In previews it throws preview errors instead of calling Firebase.
 final class FirebaseAuthService {
 
     // MARK: - State & Identity
+
+    private enum TermsAcceptanceField {
+        static let termsVersion = "termsVersion"
+        static let acceptedAt = "acceptedAt"
+        static let appVersion = "appVersion"
+    }
 
     /// True when the current user is a guest account.
     var isAnonymous: Bool {
@@ -127,18 +141,48 @@ final class FirebaseAuthService {
     }
 
     /// Creates an email account or upgrades a guest account.
-    /// Sends a verification email and then signs out.
-    func createOrUpgradeEmailAccountRequiringVerification(email: String, password: String) async throws {
+    /// Optionally stores accepted terms metadata, sends a verification email, then signs out.
+    func createOrUpgradeEmailAccountRequiringVerification(
+        email: String,
+        password: String,
+        acceptedTermsVersion: String? = nil,
+        appVersion: String? = nil
+    ) async throws {
         guard !ProcessInfo.processInfo.isPreview else { throw PreviewAuthError() }
 
         let user = try await createOrUpgradeEmailAccount(email: email, password: password)
         do {
+            if let acceptedTermsVersion {
+                try await storeTermsAcceptance(
+                    for: user.uid,
+                    termsVersion: acceptedTermsVersion,
+                    appVersion: appVersion
+                )
+            }
             try await sendVerificationEmail(to: user)
         } catch {
             try? signOut()
             throw error
         }
         try signOut()
+    }
+
+    /// Stores current terms acceptance for the signed in user.
+    func storeTermsAcceptanceForCurrentUser(
+        termsVersion: String,
+        appVersion: String? = nil
+    ) async throws {
+        guard !ProcessInfo.processInfo.isPreview else { throw PreviewAuthError() }
+        guard let uid = currentUserID else { throw AuthServiceError.noCurrentUser }
+        try await storeTermsAcceptance(for: uid, termsVersion: termsVersion, appVersion: appVersion)
+    }
+
+    /// Loads stored terms acceptance for the signed in user.
+    /// Returns nil when no acceptance data exists.
+    func loadTermsAcceptanceForCurrentUser() async throws -> TermsAcceptanceSnapshot? {
+        guard !ProcessInfo.processInfo.isPreview else { throw PreviewAuthError() }
+        guard let uid = currentUserID else { throw AuthServiceError.noCurrentUser }
+        return try await loadTermsAcceptance(for: uid)
     }
 
     /// Sends a verification email to the current user.
@@ -264,6 +308,54 @@ final class FirebaseAuthService {
                 if let error { cont.resume(throwing: error) } else { cont.resume() }
             }
         }
+    }
+
+    private func storeTermsAcceptance(
+        for uid: String,
+        termsVersion: String,
+        appVersion: String?
+    ) async throws {
+        let payload = makeTermsAcceptancePayload(termsVersion: termsVersion, appVersion: appVersion)
+
+        try await FirestorePaths
+            .userDoc(uid: uid, in: Firestore.firestore())
+            .setData(payload, merge: true)
+    }
+
+    private func loadTermsAcceptance(for uid: String) async throws -> TermsAcceptanceSnapshot? {
+        let snapshot = try await FirestorePaths
+            .userDoc(uid: uid, in: Firestore.firestore())
+            .getDocument()
+
+        guard let data = snapshot.data() else { return nil }
+        let version = (data[TermsAcceptanceField.termsVersion] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let version, !version.isEmpty else { return nil }
+
+        let acceptedAtDate = (data[TermsAcceptanceField.acceptedAt] as? Timestamp)?.dateValue()
+        let storedAppVersion = (data[TermsAcceptanceField.appVersion] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedAppVersion = (storedAppVersion?.isEmpty == false) ? storedAppVersion : nil
+
+        return TermsAcceptanceSnapshot(
+            termsVersion: version,
+            acceptedAt: acceptedAtDate,
+            appVersion: normalizedAppVersion
+        )
+    }
+
+    private func makeTermsAcceptancePayload(
+        termsVersion: String,
+        appVersion: String?
+    ) -> [String: Any] {
+        var payload: [String: Any] = [
+            TermsAcceptanceField.termsVersion: termsVersion,
+            TermsAcceptanceField.acceptedAt: FieldValue.serverTimestamp()
+        ]
+        if let appVersion, !appVersion.isEmpty {
+            payload[TermsAcceptanceField.appVersion] = appVersion
+        }
+        return payload
     }
 
     private func describe(error: Error) -> String {

--- a/CineMate/CineMate/Core/Firebase/Auth/Validation/TermsContent.swift
+++ b/CineMate/CineMate/Core/Firebase/Auth/Validation/TermsContent.swift
@@ -8,9 +8,11 @@
 import Foundation
 
 enum TermsContent {
+    static let currentVersion = "2026-04-10"
+
     /// Short markdown for the “View terms” sheet.
     static let termsMarkdown = """
-    **Last updated:** 2026-04-10
+    **Last updated:** \(currentVersion)
     
     ## About
     CineMate uses Firebase Auth for sign-in and TMDB for movie data and images.

--- a/CineMate/CineMate/Core/Firebase/Auth/Validation/TermsContent.swift
+++ b/CineMate/CineMate/Core/Firebase/Auth/Validation/TermsContent.swift
@@ -10,35 +10,38 @@ import Foundation
 enum TermsContent {
     /// Short markdown for the “View terms” sheet.
     static let termsMarkdown = """
-    **Last updated:** 2025-09-10
-
+    **Last updated:** 2026-04-10
+    
     ## About
-    CineMate uses Firebase Auth for sign-in and TMDB for artwork/metadata.  
-    > Uses the TMDB API but is not endorsed or certified by TMDB.
-
+    CineMate uses Firebase Auth for sign-in and TMDB for movie data and images.
+    
+    ## TMDB Notice
+    > This product uses the TMDB API but is not endorsed or certified by TMDB.
+    
     ## Eligibility
     You must be 13+ (or the local minimum).
-
+    
     ## Account
     Keep your credentials secure and follow applicable laws.
-
+    
     ## Data & Privacy
-    We store minimal data (email, user ID, favorites).  
+    We store minimal data (email, user ID, favorites).
     Passwords are handled by Firebase. All requests use HTTPS.
-
-    ## TMDB Content
-    Posters and metadata may change.  
-    See the [TMDB Terms](https://www.themoviedb.org/terms-of-use).
-
+    
+    ## TMDB Terms
+    TMDB data and images may change at any time.
+    Usage must follow the [TMDB API Terms of Use](https://www.themoviedb.org/api-terms-of-use) and the [TMDB Terms of Use](https://www.themoviedb.org/terms-of-use).
+    Attribution and branding requirements are described in the [TMDB FAQ](https://developer.themoviedb.org/docs/faq).
+    
     ## Acceptable Use
     No scraping, abuse, or IP infringement.
-
+    
     ## Warranty
     Provided “as is,” without warranties. We are not liable for losses.
-
+    
     ## Updates
     Using the app means you accept changes to these terms.
-
+    
     ## Support
     **Contact:** Open a GitHub Issue on the project repository.
     """

--- a/CineMate/CineMate/Core/Firebase/Auth/ViewModels/AuthViewModel.swift
+++ b/CineMate/CineMate/Core/Firebase/Auth/ViewModels/AuthViewModel.swift
@@ -25,6 +25,9 @@ final class AuthViewModel: ObservableObject {
     /// Error text shown by the UI.
     @Published var errorMessage: String?
     
+    /// Saved terms acceptance metadata for this account.
+    @Published private(set) var termsAcceptance: TermsAcceptanceSnapshot?
+    
     /// End time for change email cooldown.
     private var changeEmailCooldownUntil: Date?
     
@@ -72,6 +75,7 @@ final class AuthViewModel: ObservableObject {
         if ProcessInfo.processInfo.isPreview {
             guard errorMessage == nil else { return }
             currentUID = currentUID ?? AuthPreviewData.demoUID
+            termsAcceptance = nil
             return
         }
         
@@ -81,6 +85,7 @@ final class AuthViewModel: ObservableObject {
         do {
             let uid = try await service.signInAnonymously()
             currentUID = uid
+            termsAcceptance = nil
             errorMessage = nil
         } catch {
             errorMessage = AuthAppError.userMessage(for: error)
@@ -91,6 +96,7 @@ final class AuthViewModel: ObservableObject {
     func signOut() async {
         if ProcessInfo.processInfo.isPreview {
             currentUID = nil
+            termsAcceptance = nil
             errorMessage = nil
             changeEmailCooldownUntil = nil
             return
@@ -107,6 +113,7 @@ final class AuthViewModel: ObservableObject {
                 try service.signOut()
             }
             currentUID = nil
+            termsAcceptance = nil
             errorMessage = nil
             changeEmailCooldownUntil = nil
         } catch {
@@ -117,7 +124,14 @@ final class AuthViewModel: ObservableObject {
     /// Reloads auth user data from server and refreshes local account info.
     func refreshCurrentUserFromServer() async {
         if ProcessInfo.processInfo.isPreview { return }
-        guard let service, currentUID != nil else { return }
+        guard let service else {
+            termsAcceptance = nil
+            return
+        }
+        guard currentUID != nil else {
+            termsAcceptance = nil
+            return
+        }
         
         do {
             try await service.reloadCurrentUser()
@@ -127,6 +141,7 @@ final class AuthViewModel: ObservableObject {
             currentUID = service.currentUserID
             logAuth("refreshCurrentUser failed \(describe(error: error))")
         }
+        await refreshTermsAcceptance()
     }
 }
 
@@ -246,11 +261,13 @@ extension AuthViewModel {
             switch result {
             case .success:
                 self.currentUID = nil
+                self.termsAcceptance = nil
                 self.errorMessage = nil
                 self.changeEmailCooldownUntil = nil
                 return .success
             case .requiresRecentLogin:
                 self.currentUID = nil
+                self.termsAcceptance = nil
                 self.errorMessage = nil
                 self.changeEmailCooldownUntil = nil
                 return .needsRecentLogin
@@ -292,6 +309,45 @@ extension AuthViewModel {
     var canChangeEmail: Bool {
         if ProcessInfo.processInfo.isPreview { return currentUID != nil }
         return service?.canChangeEmail ?? false
+    }
+    
+    /// Accepted terms version shown on the account screen.
+    var acceptedTermsVersionText: String? {
+        termsAcceptance?.termsVersion
+    }
+    
+    /// Accepted timestamp shown on the account screen.
+    var acceptedTermsAtText: String? {
+        guard let date = termsAcceptance?.acceptedAt else { return nil }
+        return date.formatted(date: .abbreviated, time: .shortened)
+    }
+    
+    /// App version used when the user accepted terms.
+    var acceptedTermsAppVersionText: String? {
+        termsAcceptance?.appVersion
+    }
+    
+    /// One-line legal summary shown on the account screen.
+    var acceptedTermsSummaryText: String? {
+        guard let version = termsAcceptance?.termsVersion else { return nil }
+        if let acceptedAt = termsAcceptance?.acceptedAt {
+            return "You accepted version \(version) on \(formattedTermsDate(acceptedAt))."
+        }
+        return "You accepted version \(version)."
+    }
+    
+    /// True when the saved terms version is older than the current app terms.
+    var isAcceptedTermsOutdated: Bool {
+        guard let acceptedVersion = termsAcceptance?.termsVersion else { return false }
+        guard acceptedVersion != TermsContent.currentVersion else { return false }
+        
+        guard
+            let acceptedDate = termsVersionDate(from: acceptedVersion),
+            let currentDate = termsVersionDate(from: TermsContent.currentVersion)
+        else {
+            return true
+        }
+        return acceptedDate < currentDate
     }
 }
 
@@ -338,5 +394,99 @@ private extension AuthViewModel {
 #if DEBUG
         print("[App][Auth][ViewModel] \(message)")
 #endif
+    }
+    
+    var appVersionForLegalAudit: String? {
+        let raw = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+        let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return (trimmed?.isEmpty == false) ? trimmed : nil
+    }
+    
+    func termsVersionDate(from raw: String) -> Date? {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.date(from: raw.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+    
+    func formattedTermsDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
+    }
+}
+
+// MARK: - Legal metadata API
+
+extension AuthViewModel {
+    /// Result for accepting latest terms on the account screen.
+    enum AcceptTermsResult {
+        case saved
+        case unavailable
+        case failure(String)
+    }
+    
+    /// Stores the current terms version for the signed in user.
+    func acceptCurrentTermsVersion() async -> AcceptTermsResult {
+        if ProcessInfo.processInfo.isPreview {
+            termsAcceptance = TermsAcceptanceSnapshot(
+                termsVersion: TermsContent.currentVersion,
+                acceptedAt: Date(),
+                appVersion: "Preview"
+            )
+            return .saved
+        }
+        
+        guard let service, currentUID != nil, !service.isAnonymous else {
+            return .unavailable
+        }
+        
+        isAuthenticating = true
+        defer { isAuthenticating = false }
+        
+        do {
+            try await service.storeTermsAcceptanceForCurrentUser(
+                termsVersion: TermsContent.currentVersion,
+                appVersion: appVersionForLegalAudit
+            )
+            termsAcceptance = try await service.loadTermsAcceptanceForCurrentUser()
+            errorMessage = nil
+            return .saved
+        } catch {
+            let message = AuthAppError.userMessage(for: error)
+            errorMessage = message
+            return .failure(message)
+        }
+    }
+    
+    /// Loads saved terms acceptance metadata for the current user.
+    func refreshTermsAcceptance() async {
+        if ProcessInfo.processInfo.isPreview {
+            termsAcceptance = currentUID == nil
+            ? nil
+            : TermsAcceptanceSnapshot(
+                termsVersion: TermsContent.currentVersion,
+                acceptedAt: Date(),
+                appVersion: "Preview"
+            )
+            return
+        }
+        
+        guard let service, currentUID != nil, !service.isAnonymous else {
+            termsAcceptance = nil
+            return
+        }
+        
+        do {
+            termsAcceptance = try await service.loadTermsAcceptanceForCurrentUser()
+        } catch {
+            termsAcceptance = nil
+            logAuth("refreshTermsAcceptance failed \(describe(error: error))")
+        }
     }
 }

--- a/CineMate/CineMate/Features/Account/Auth/ViewModels/CreateAccountViewModel.swift
+++ b/CineMate/CineMate/Features/Account/Auth/ViewModels/CreateAccountViewModel.swift
@@ -94,7 +94,9 @@ final class CreateAccountViewModel: ObservableObject {
         do {
             try await service.createOrUpgradeEmailAccountRequiringVerification(
                 email: email,
-                password: password
+                password: password,
+                acceptedTermsVersion: TermsContent.currentVersion,
+                appVersion: appVersionForLegalAudit
             )
             appError = nil
             onVerificationEmailSent()
@@ -105,5 +107,11 @@ final class CreateAccountViewModel: ObservableObject {
 
     func clearError() {
         appError = nil
+    }
+
+    private var appVersionForLegalAudit: String? {
+        let raw = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+        let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return (trimmed?.isEmpty == false) ? trimmed : nil
     }
 }

--- a/CineMate/CineMate/Features/Account/Auth/Views/AccountView.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Views/AccountView.swift
@@ -14,11 +14,13 @@ struct AccountView: View {
     @EnvironmentObject private var toastCenter: ToastCenter
     @Environment(\.scenePhase) private var scenePhase
     @State private var isShowingChangeEmailSheet = false
-    
+    @State private var isShowingTermsSheet = false
+    @State private var hasReviewedUpdates = false
+
     init(viewModel: AuthViewModel) {
         self._authViewModel = ObservedObject(wrappedValue: viewModel)
     }
-    
+
     var body: some View {
         ZStack {
             Form {
@@ -40,7 +42,7 @@ struct AccountView: View {
                         }
                     }
                 }
-                
+
                 if authViewModel.isSignedIn {
                     Section("Provider") {
                         HStack {
@@ -51,12 +53,12 @@ struct AccountView: View {
                                 .multilineTextAlignment(.trailing)
                         }
                     }
-                    
+
                     if authViewModel.isGuest {
                         Section("Guest account") {
                             Text("Create an account to unlock Discover and Search.")
                                 .foregroundStyle(Color.appTextSecondary)
-                            
+
                             Button("Create Account") {
                                 navigator.goToCreateAccount()
                             }
@@ -65,7 +67,7 @@ struct AccountView: View {
                             .disabled(authViewModel.isAuthenticating)
                         }
                     }
-                    
+
                     if !authViewModel.isGuest {
                         Section("Email") {
                             if let email = authViewModel.currentUserEmail {
@@ -77,7 +79,7 @@ struct AccountView: View {
                                         .multilineTextAlignment(.trailing)
                                 }
                             }
-                            
+
                             if authViewModel.canChangeEmail {
                                 Button("Change email") {
                                     isShowingChangeEmailSheet = true
@@ -90,22 +92,93 @@ struct AccountView: View {
                             }
                         }
                     }
-                    
+
                     if !authViewModel.isGuest {
+                        Section("Legal") {
+                            if let summary = authViewModel.acceptedTermsSummaryText {
+                                Text(summary)
+                                    .foregroundStyle(Color.appTextSecondary)
+                            } else {
+                                Text("No saved terms acceptance for this account yet.")
+                                    .foregroundStyle(Color.appTextSecondary)
+                            }
+
+                            if authViewModel.isAcceptedTermsOutdated {
+                                Button {
+                                    let wasReviewed = hasReviewedUpdates
+                                    hasReviewedUpdates = true
+                                    if !wasReviewed {
+                                        toastCenter.show("Review complete. You can accept the update.")
+                                    }
+                                    isShowingTermsSheet = true
+                                } label: {
+                                    Label(
+                                        hasReviewedUpdates ? "Reviewed" : "Review updates",
+                                        systemImage: hasReviewedUpdates ? "checkmark.circle.fill" : "exclamationmark.triangle.fill"
+                                    )
+                                    .font(.footnote.weight(.semibold))
+                                    .foregroundStyle(hasReviewedUpdates ? Color.appTextSecondary : .orange)
+                                }
+                                .buttonStyle(.plain)
+                            } else if authViewModel.acceptedTermsSummaryText != nil {
+                                Label("Up to date", systemImage: "checkmark.seal.fill")
+                                    .font(.footnote.weight(.semibold))
+                                    .foregroundStyle(.green)
+                            }
+
+                            if let appVersion = authViewModel.acceptedTermsAppVersionText {
+                                HStack {
+                                    Text("App version")
+                                    Spacer()
+                                    Text(appVersion)
+                                        .foregroundStyle(Color.appTextSecondary)
+                                        .multilineTextAlignment(.trailing)
+                                }
+                            }
+
+                            Button("View terms") {
+                                isShowingTermsSheet = true
+                            }
+                            .buttonStyle(.bordered)
+                            .disabled(authViewModel.isAuthenticating)
+
+                            if authViewModel.isAcceptedTermsOutdated || authViewModel.acceptedTermsSummaryText == nil {
+                                let requiresReviewBeforeAccept = authViewModel.isAcceptedTermsOutdated && !hasReviewedUpdates
+
+                                Button(authViewModel.isAcceptedTermsOutdated ? "Accept update" : "Accept latest terms") {
+                                    Task {
+                                        let result = await authViewModel.acceptCurrentTermsVersion()
+                                        handleAcceptTermsResult(result)
+                                    }
+                                }
+                                .buttonStyle(.borderedProminent)
+                                .tint(.appPrimaryAction)
+                                .disabled(
+                                    authViewModel.isAuthenticating || requiresReviewBeforeAccept
+                                )
+
+                                if requiresReviewBeforeAccept {
+                                    Text("Review required before accepting.")
+                                        .font(.footnote)
+                                        .foregroundStyle(Color.appTextSecondary)
+                                }
+                            }
+                        }
+
                         Section("Security") {
                             if authViewModel.canSendPasswordReset {
                                 if let email = authViewModel.currentUserEmail {
                                     Text("Reset links are sent to \(email).")
                                         .foregroundStyle(Color.appTextSecondary)
                                 }
-                                
+
                                 Button("Change password") {
                                     Task {
                                         switch await authViewModel.sendPasswordResetForCurrentUser() {
                                         case .sent(let email):
-                                            toastCenter.show("Password reset link sent to \(email)")
+                                            toastCenter.show("Password reset link sent to \(email).")
                                         case .unavailable:
-                                            toastCenter.show("Password reset is only available for email sign-in")
+                                            toastCenter.show("Password reset is only available for email sign in.")
                                         case .failure(let message):
                                             toastCenter.show(message)
                                         }
@@ -119,14 +192,14 @@ struct AccountView: View {
                             }
                         }
                     }
-                    
+
                     Section("Actions") {
                         Button(authViewModel.isGuest ? "End guest session" : "Sign out") {
                             Task {
                                 let wasGuest = authViewModel.isGuest
                                 await authViewModel.signOut()
                                 if wasGuest, authViewModel.errorMessage == nil {
-                                    toastCenter.show("Guest session ended")
+                                    toastCenter.show("Guest session ended.")
                                 }
                             }
                         }
@@ -134,15 +207,15 @@ struct AccountView: View {
                         .tint(.appPrimaryAction)
                         .disabled(authViewModel.isAuthenticating)
                     }
-                    
+
                     if !authViewModel.isGuest {
                         AccountDangerZoneView(
                             authViewModel: authViewModel,
                             onReauthenticationRequired: {
-                                toastCenter.show("Please sign in again to delete your account")
+                                toastCenter.show("Please sign in again to delete your account.")
                             },
                             onDeleteSuccess: {
-                                toastCenter.show("Account deleted successfully")
+                                toastCenter.show("Account deleted.")
                             },
                             onDeleteFailure: { message in
                                 toastCenter.show(message)
@@ -164,7 +237,10 @@ struct AccountView: View {
                     }
                 )
             }
-            
+            .sheet(isPresented: $isShowingTermsSheet) {
+                TermsSheet(markdown: TermsContent.termsMarkdown)
+            }
+
             if let error = authViewModel.errorMessage {
                 ErrorMessageView(
                     title: "Authentication Error",
@@ -176,22 +252,43 @@ struct AccountView: View {
             }
         }
         .animation(.default, value: authViewModel.errorMessage != nil)
+        .task(id: authViewModel.currentUID) {
+            await authViewModel.refreshTermsAcceptance()
+        }
         .onChange(of: scenePhase) { _, newPhase in
             guard newPhase == .active else { return }
             Task { await authViewModel.refreshCurrentUserFromServer() }
         }
+        .onChange(of: authViewModel.isAcceptedTermsOutdated) { _, isOutdated in
+            if isOutdated {
+                hasReviewedUpdates = false
+            } else {
+                hasReviewedUpdates = true
+            }
+        }
     }
-    
+
     private func handleChangeEmailResult(_ result: AuthViewModel.ChangeEmailResult) {
         switch result {
         case .verificationSent(let email):
-            toastCenter.show("Verification link sent to \(email)")
+            toastCenter.show("Verification link sent to \(email).")
         case .unavailable:
-            toastCenter.show("Email change is only available for email sign-in")
+            toastCenter.show("Email change is only available for email sign in.")
         case .cooldown(let seconds):
-            toastCenter.show("Please wait \(seconds) seconds before sending another link")
+            toastCenter.show("Wait \(seconds) seconds before sending another link.")
         case .needsRecentLogin:
-            toastCenter.show("Please sign in again to change your email")
+            toastCenter.show("Please sign in again to change your email.")
+        case .failure(let message):
+            toastCenter.show(message)
+        }
+    }
+
+    private func handleAcceptTermsResult(_ result: AuthViewModel.AcceptTermsResult) {
+        switch result {
+        case .saved:
+            toastCenter.show("Accepted terms version \(TermsContent.currentVersion).")
+        case .unavailable:
+            toastCenter.show("Terms acceptance not available for this account.")
         case .failure(let message):
             toastCenter.show(message)
         }

--- a/CineMate/CineMate/Features/UI/Components/Sheets/TermSheet.swift
+++ b/CineMate/CineMate/Features/UI/Components/Sheets/TermSheet.swift
@@ -12,83 +12,73 @@ struct TermsSheet: View {
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
-        ZStack {
-            LinearGradient(
-                colors: [AuthTheme.curtainTop, AuthTheme.curtainBottom],
-                startPoint: .top, endPoint: .bottom
-            )
-            .ignoresSafeArea()
+        GeometryReader { geometry in
+            let horizontalInset = max(SharedUI.Spacing.medium, min(SharedUI.Spacing.large, geometry.size.width * 0.04))
 
-            VStack(spacing: 22) {
-                TermsHeader()
+            ZStack {
+                LinearGradient(
+                    colors: [AuthTheme.curtainTop, AuthTheme.curtainBottom],
+                    startPoint: .top, endPoint: .bottom
+                )
+                .ignoresSafeArea()
 
-                ScrollView {
-                    Text(markdownAttributed)
-                        .lineSpacing(6)
-                        .foregroundStyle(AuthTheme.iconOnCurtain.opacity(0.92))
+                VStack(spacing: SharedUI.Spacing.large) {
+                    TermsHeader()
+                        .padding(.top, SharedUI.Spacing.small)
+
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: SharedUI.Spacing.large) {
+                            ForEach(Array(termsBlocks.enumerated()), id: \.offset) { _, block in
+                                TermsBlockView(block: block)
+                            }
+                        }
                         .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(SharedUI.Spacing.xLarge)
+                        .padding(.horizontal, SharedUI.Spacing.large)
+                        .padding(.vertical, SharedUI.Spacing.xLarge)
                         .background(
                             RoundedRectangle(
-                                cornerRadius: SharedUI.Radius.sheet, style: .continuous
+                                cornerRadius: SharedUI.Radius.sheet,
+                                style: .continuous
                             )
                             .fill(Color.appSurface.opacity(0.18))
                             .overlay(
                                 RoundedRectangle(
-                                    cornerRadius: SharedUI.Radius.sheet, style: .continuous
+                                    cornerRadius: SharedUI.Radius.sheet,
+                                    style: .continuous
                                 )
                                 .stroke(AuthTheme.cardStroke)
                             )
                         )
                         .shadow(color: .black.opacity(0.12), radius: 10, y: 4)
-                        .padding(.horizontal, SharedUI.Spacing.xLarge)
-                }
-                .scrollIndicators(.never)
+                        .padding(.horizontal, horizontalInset)
+                        .padding(.vertical, SharedUI.Spacing.xSmall)
+                    }
+                    .scrollIndicators(.never)
 
-                Button {
-                    dismiss()
-                } label: {
-                    Text("Close").fontWeight(.semibold).frame(maxWidth: .infinity)
+                    Button {
+                        dismiss()
+                    } label: {
+                        Text("Close")
+                            .fontWeight(.semibold)
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.pillWhite)
+                    .frame(height: 48)
+                    .padding(.horizontal, horizontalInset)
                 }
-                .buttonStyle(.pillWhite)
-                .frame(height: 48)
-                .padding(.horizontal, SharedUI.Spacing.xLarge)
+                .frame(maxWidth: 680)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                .padding(.bottom, SharedUI.Spacing.large)
+                .padding(.top, SharedUI.Spacing.xSmall)
             }
-            .padding(.bottom, SharedUI.Spacing.large)
+            .tint(AuthTheme.popcorn)
+            .presentationDetents([.large])
+            .presentationDragIndicator(.visible)
         }
-        .tint(AuthTheme.popcorn)
-        .presentationDetents([.large])
-        .presentationDragIndicator(.visible)
     }
 
-    // MARK: - Helper
-    private var markdownAttributed: AttributedString {
-        (try? AttributedString(markdown: markdown)) ?? AttributedString(markdown)
-    }
-}
-
-private struct TermsHeader: View {
-    var body: some View {
-        VStack(spacing: 10) {
-            ZStack {
-                Circle()
-                    .fill(Color.appSurface.opacity(0.16))
-                    .frame(width: 64, height: 64)
-                    .overlay(Circle().strokeBorder(AuthTheme.cardStroke))
-                Image(systemName: "doc.text")
-                    .font(.system(size: 24, weight: .semibold))
-                    .symbolRenderingMode(.hierarchical)
-                    .foregroundStyle(AuthTheme.iconOnCurtain)
-            }
-            Text("Terms of Service")
-                .font(.title3.bold())
-                .foregroundStyle(AuthTheme.iconOnCurtain)
-
-            Text("Please review before creating an account")
-                .font(.subheadline)
-                .foregroundStyle(.white.opacity(0.9))
-        }
-        .padding(.top, 15)
+    private var termsBlocks: [TermsBlock] {
+        TermsMarkdownParser.parse(markdown)
     }
 }
 

--- a/CineMate/CineMate/Features/UI/Components/Sheets/TermsBlockView.swift
+++ b/CineMate/CineMate/Features/UI/Components/Sheets/TermsBlockView.swift
@@ -1,0 +1,46 @@
+//
+//  TermsBlockView.swift
+//  CineMate
+//
+//  Created by Nicholas Samuelsson Jeria on 2026-04-10.
+//
+
+import SwiftUI
+
+struct TermsBlockView: View {
+    let block: TermsBlock
+
+    var body: some View {
+        switch block {
+        case .heading(let text):
+            Text(text)
+                .font(.headline.weight(.semibold))
+                .foregroundStyle(AuthTheme.textOnCurtainPrimary)
+
+        case .quote(let text):
+            Text(markdownInline(text))
+                .font(.callout)
+                .lineSpacing(6)
+                .foregroundStyle(AuthTheme.iconOnCurtain.opacity(0.92))
+                .padding(.horizontal, SharedUI.Spacing.medium)
+                .padding(.vertical, SharedUI.Spacing.small)
+                .background(
+                    Color.white.opacity(0.08),
+                    in: RoundedRectangle(cornerRadius: SharedUI.Radius.medium, style: .continuous)
+                )
+
+        case .paragraph(let text):
+            Text(markdownInline(text))
+                .font(.callout)
+                .lineSpacing(7)
+                .foregroundStyle(AuthTheme.iconOnCurtain.opacity(0.92))
+        }
+    }
+
+    private func markdownInline(_ text: String) -> AttributedString {
+        let options = AttributedString.MarkdownParsingOptions(
+            interpretedSyntax: .inlineOnlyPreservingWhitespace
+        )
+        return (try? AttributedString(markdown: text, options: options)) ?? AttributedString(text)
+    }
+}

--- a/CineMate/CineMate/Features/UI/Components/Sheets/TermsHeader.swift
+++ b/CineMate/CineMate/Features/UI/Components/Sheets/TermsHeader.swift
@@ -1,0 +1,35 @@
+//
+//  TermsHeader.swift
+//  CineMate
+//
+//  Created by Nicholas Samuelsson Jeria on 2026-04-10.
+//
+
+import SwiftUI
+
+struct TermsHeader: View {
+    var body: some View {
+        VStack(spacing: 10) {
+            ZStack {
+                Circle()
+                    .fill(Color.appSurface.opacity(0.16))
+                    .frame(width: 64, height: 64)
+                    .overlay(Circle().strokeBorder(AuthTheme.cardStroke))
+                Image(systemName: "doc.text")
+                    .font(.system(size: 24, weight: .semibold))
+                    .symbolRenderingMode(.hierarchical)
+                    .foregroundStyle(AuthTheme.iconOnCurtain)
+            }
+            Text("Terms of Service")
+                .font(.title3.bold())
+                .foregroundStyle(AuthTheme.iconOnCurtain)
+            
+            Text("Please review before creating an account")
+                .font(.subheadline)
+                .foregroundStyle(.white.opacity(0.9))
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, SharedUI.Spacing.large)
+        }
+        .padding(.top, 15)
+    }
+}

--- a/CineMate/CineMate/Features/UI/Components/Sheets/TermsMarkdownParser.swift
+++ b/CineMate/CineMate/Features/UI/Components/Sheets/TermsMarkdownParser.swift
@@ -1,0 +1,54 @@
+//
+//  TermsMarkdownParser.swift
+//  CineMate
+//
+//  Created by Nicholas Samuelsson Jeria on 2026-04-10.
+//
+
+import Foundation
+
+enum TermsBlock {
+    case heading(String)
+    case quote(String)
+    case paragraph(String)
+}
+
+enum TermsMarkdownParser {
+    static func parse(_ markdown: String) -> [TermsBlock] {
+        var blocks: [TermsBlock] = []
+        var paragraphLines: [String] = []
+
+        func flushParagraph() {
+            let paragraph = paragraphLines.joined(separator: " ")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !paragraph.isEmpty else { return }
+            blocks.append(.paragraph(paragraph))
+            paragraphLines.removeAll()
+        }
+
+        for line in markdown.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else {
+                flushParagraph()
+                continue
+            }
+
+            if trimmed.hasPrefix("## ") {
+                flushParagraph()
+                blocks.append(.heading(String(trimmed.dropFirst(3))))
+                continue
+            }
+
+            if trimmed.hasPrefix("> ") {
+                flushParagraph()
+                blocks.append(.quote(String(trimmed.dropFirst(2))))
+                continue
+            }
+
+            paragraphLines.append(trimmed)
+        }
+
+        flushParagraph()
+        return blocks
+    }
+}

--- a/CineMate/firestore.rules
+++ b/CineMate/firestore.rules
@@ -7,14 +7,28 @@ service cloud.firestore {
       return request.auth != null && request.auth.uid == uid;
     }
 
+    // Keep this in sync with TermsContent.currentVersion in the app.
+    function currentTermsVersion() {
+      return "2026-04-10";
+    }
+
+    // True when the user doc has accepted the current terms version.
+    function hasAcceptedCurrentTerms(uid) {
+      return exists(/databases/$(database)/documents/users/$(uid))
+        && get(/databases/$(database)/documents/users/$(uid)).data.termsVersion == currentTermsVersion()
+        && get(/databases/$(database)/documents/users/$(uid)).data.acceptedAt is timestamp;
+    }
+
     // Allow a user to read/write their own user doc.
     match /users/{uid} {
       allow read, write: if isOwner(uid);
     }
 
-    // Allow reads/writes for anything under the user's subtree.
+    // Allow reads for the owner.
+    // Allow writes only after accepting the current terms version.
     match /users/{uid}/{document=**} {
-      allow read, write: if isOwner(uid);
+      allow read: if isOwner(uid);
+      allow write: if isOwner(uid) && hasAcceptedCurrentTerms(uid);
     }
 
     // Everything else denied by default.

--- a/CineMate/functions/README.md
+++ b/CineMate/functions/README.md
@@ -6,6 +6,7 @@ This folder contains backend cleanup automation for account deletion.
 
 - `cleanupUserDataOnDelete` runs when a Firebase Auth user is deleted.
 - It recursively deletes `/users/{uid}` and all nested subcollections.
+- Firestore rules tests check terms enforcement for user data writes.
 
 ## First-time setup
 
@@ -15,6 +16,12 @@ This folder contains backend cleanup automation for account deletion.
    - `npm install`
 3. Deploy:
    - `npm run deploy`
+
+## Firestore rules tests
+
+- Run emulator tests:
+  - `npm run test:rules`
+- This starts the Firestore emulator, runs the rules test suite, and stops the emulator.
 
 ## Notes
 

--- a/CineMate/functions/package-lock.json
+++ b/CineMate/functions/package-lock.json
@@ -10,6 +10,7 @@
         "firebase-functions": "^6.0.0"
       },
       "devDependencies": {
+        "@firebase/rules-unit-testing": "^4.0.1",
         "typescript": "^5.9.0"
       },
       "engines": {
@@ -22,11 +23,413 @@
       "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
       "license": "MIT"
     },
+    "node_modules/@firebase/ai": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-1.4.1.tgz",
+      "integrity": "sha512-bcusQfA/tHjUjBTnMx6jdoPMpDl3r8K15Z+snHz9wq0Foox0F/V+kNLXucEOHoTL2hTc9l+onZCyBJs2QoIC3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/component": "0.6.18",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/ai/node_modules/@firebase/component": {
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.18.tgz",
+      "integrity": "sha512-n28kPCkE2dL2U28fSxZJjzPPVpKsQminJ6NrzcKXAI0E/lYC8YhfwpyllScqVEvAI3J2QgJZWYgrX+1qGI+SQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/ai/node_modules/@firebase/logger": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.4.tgz",
+      "integrity": "sha512-mH0PEh1zoXGnaR8gD1DeGeNZtWFKbnz9hDO91dIml3iou1gpOnLqXQ2dJfB71dj6dpmUjcQ6phY3ZZJbjErr9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/ai/node_modules/@firebase/util": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.12.1.tgz",
+      "integrity": "sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/analytics": {
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.17.tgz",
+      "integrity": "sha512-n5vfBbvzduMou/2cqsnKrIes4auaBjdhg8QNA2ZQZ59QgtO2QiwBaXQZQE4O4sgB0Ds1tvLgUUkY+pwzu6/xEg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/component": "0.6.18",
+        "@firebase/installations": "0.6.18",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-compat": {
+      "version": "0.2.23",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.23.tgz",
+      "integrity": "sha512-3AdO10RN18G5AzREPoFgYhW6vWXr3u+OYQv6pl3CX6Fky8QRk0AHurZlY3Q1xkXO0TDxIsdhO3y65HF7PBOJDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/analytics": "0.10.17",
+        "@firebase/analytics-types": "0.8.3",
+        "@firebase/component": "0.6.18",
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-compat/node_modules/@firebase/component": {
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.18.tgz",
+      "integrity": "sha512-n28kPCkE2dL2U28fSxZJjzPPVpKsQminJ6NrzcKXAI0E/lYC8YhfwpyllScqVEvAI3J2QgJZWYgrX+1qGI+SQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/analytics-compat/node_modules/@firebase/util": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.12.1.tgz",
+      "integrity": "sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/analytics-types": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.3.tgz",
+      "integrity": "sha512-VrIp/d8iq2g501qO46uGz3hjbDb8xzYMrbu8Tp0ovzIzrvJZ2fvmj649gTjge/b7cCCcjT0H37g1gVtlNhnkbg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true
+    },
+    "node_modules/@firebase/analytics/node_modules/@firebase/component": {
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.18.tgz",
+      "integrity": "sha512-n28kPCkE2dL2U28fSxZJjzPPVpKsQminJ6NrzcKXAI0E/lYC8YhfwpyllScqVEvAI3J2QgJZWYgrX+1qGI+SQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/analytics/node_modules/@firebase/logger": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.4.tgz",
+      "integrity": "sha512-mH0PEh1zoXGnaR8gD1DeGeNZtWFKbnz9hDO91dIml3iou1gpOnLqXQ2dJfB71dj6dpmUjcQ6phY3ZZJbjErr9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/analytics/node_modules/@firebase/util": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.12.1.tgz",
+      "integrity": "sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/app": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.13.2.tgz",
+      "integrity": "sha512-jwtMmJa1BXXDCiDx1vC6SFN/+HfYG53UkfJa6qeN5ogvOunzbFDO3wISZy5n9xgYFUrEP6M7e8EG++riHNTv9w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/component": "0.6.18",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.12.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/app-check": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.10.1.tgz",
+      "integrity": "sha512-MgNdlms9Qb0oSny87pwpjKush9qUwCJhfmTJHDfrcKo4neLGiSeVE4qJkzP7EQTIUFKp84pbTxobSAXkiuQVYQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/component": "0.6.18",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-compat": {
+      "version": "0.3.26",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.3.26.tgz",
+      "integrity": "sha512-PkX+XJMLDea6nmnopzFKlr+s2LMQGqdyT2DHdbx1v1dPSqOol2YzgpgymmhC67vitXVpNvS3m/AiWQWWhhRRPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/app-check": "0.10.1",
+        "@firebase/app-check-types": "0.5.3",
+        "@firebase/component": "0.6.18",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-compat/node_modules/@firebase/component": {
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.18.tgz",
+      "integrity": "sha512-n28kPCkE2dL2U28fSxZJjzPPVpKsQminJ6NrzcKXAI0E/lYC8YhfwpyllScqVEvAI3J2QgJZWYgrX+1qGI+SQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/app-check-compat/node_modules/@firebase/logger": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.4.tgz",
+      "integrity": "sha512-mH0PEh1zoXGnaR8gD1DeGeNZtWFKbnz9hDO91dIml3iou1gpOnLqXQ2dJfB71dj6dpmUjcQ6phY3ZZJbjErr9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/app-check-compat/node_modules/@firebase/util": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.12.1.tgz",
+      "integrity": "sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@firebase/app-check-interop-types": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.3.tgz",
       "integrity": "sha512-gAlxfPLT2j8bTI/qfe3ahl2I2YcBQ8cFIBdhAQA4I2f3TndcO+22YizyGYuttLHPQEpWkhmpFW60VCFEPg4g5A==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-check-types": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.3.tgz",
+      "integrity": "sha512-hyl5rKSj0QmwPdsAxrI5x1otDlByQ7bvNvVt8G/XPO2CSwE++rmSVf3VEhaeOR4J8ZFaF0Z0NDSmLejPweZ3ng==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true
+    },
+    "node_modules/@firebase/app-check/node_modules/@firebase/component": {
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.18.tgz",
+      "integrity": "sha512-n28kPCkE2dL2U28fSxZJjzPPVpKsQminJ6NrzcKXAI0E/lYC8YhfwpyllScqVEvAI3J2QgJZWYgrX+1qGI+SQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/app-check/node_modules/@firebase/logger": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.4.tgz",
+      "integrity": "sha512-mH0PEh1zoXGnaR8gD1DeGeNZtWFKbnz9hDO91dIml3iou1gpOnLqXQ2dJfB71dj6dpmUjcQ6phY3ZZJbjErr9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/app-check/node_modules/@firebase/util": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.12.1.tgz",
+      "integrity": "sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/app-compat": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.4.2.tgz",
+      "integrity": "sha512-LssbyKHlwLeiV8GBATyOyjmHcMpX/tFjzRUCS1jnwGAew1VsBB4fJowyS5Ud5LdFbYpJeS+IQoC+RQxpK7eH3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/app": "0.13.2",
+        "@firebase/component": "0.6.18",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/app-compat/node_modules/@firebase/component": {
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.18.tgz",
+      "integrity": "sha512-n28kPCkE2dL2U28fSxZJjzPPVpKsQminJ6NrzcKXAI0E/lYC8YhfwpyllScqVEvAI3J2QgJZWYgrX+1qGI+SQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/app-compat/node_modules/@firebase/logger": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.4.tgz",
+      "integrity": "sha512-mH0PEh1zoXGnaR8gD1DeGeNZtWFKbnz9hDO91dIml3iou1gpOnLqXQ2dJfB71dj6dpmUjcQ6phY3ZZJbjErr9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/app-compat/node_modules/@firebase/util": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.12.1.tgz",
+      "integrity": "sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@firebase/app-types": {
       "version": "0.9.3",
@@ -34,11 +437,188 @@
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
       "license": "Apache-2.0"
     },
+    "node_modules/@firebase/app/node_modules/@firebase/component": {
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.18.tgz",
+      "integrity": "sha512-n28kPCkE2dL2U28fSxZJjzPPVpKsQminJ6NrzcKXAI0E/lYC8YhfwpyllScqVEvAI3J2QgJZWYgrX+1qGI+SQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/app/node_modules/@firebase/logger": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.4.tgz",
+      "integrity": "sha512-mH0PEh1zoXGnaR8gD1DeGeNZtWFKbnz9hDO91dIml3iou1gpOnLqXQ2dJfB71dj6dpmUjcQ6phY3ZZJbjErr9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/app/node_modules/@firebase/util": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.12.1.tgz",
+      "integrity": "sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/auth": {
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.10.8.tgz",
+      "integrity": "sha512-GpuTz5ap8zumr/ocnPY57ZanX02COsXloY6Y/2LYPAuXYiaJRf6BAGDEdRq1BMjP93kqQnKNuKZUTMZbQ8MNYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/component": "0.6.18",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^1.18.1"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth-compat": {
+      "version": "0.5.28",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.5.28.tgz",
+      "integrity": "sha512-HpMSo/cc6Y8IX7bkRIaPPqT//Jt83iWy5rmDWeThXQCAImstkdNo3giFLORJwrZw2ptiGkOij64EH1ztNJzc7Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/auth": "1.10.8",
+        "@firebase/auth-types": "0.13.0",
+        "@firebase/component": "0.6.18",
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/auth-compat/node_modules/@firebase/component": {
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.18.tgz",
+      "integrity": "sha512-n28kPCkE2dL2U28fSxZJjzPPVpKsQminJ6NrzcKXAI0E/lYC8YhfwpyllScqVEvAI3J2QgJZWYgrX+1qGI+SQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/auth-compat/node_modules/@firebase/util": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.12.1.tgz",
+      "integrity": "sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@firebase/auth-interop-types": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.4.tgz",
       "integrity": "sha512-JPgcXKCuO+CWqGDnigBtvo09HeBs5u/Ktc2GaFj2m01hLarbxthLNm7Fk8iOP1aqAtXV+fnnGj7U28xmk7IwVA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth-types": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.0.tgz",
+      "integrity": "sha512-S/PuIjni0AQRLF+l9ck0YpsMOdE8GO2KU6ubmBB7P+7TJUCQDa3R1dlgYm9UzGbbePMZsp0xzB93f2b/CgxMOg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/auth/node_modules/@firebase/component": {
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.18.tgz",
+      "integrity": "sha512-n28kPCkE2dL2U28fSxZJjzPPVpKsQminJ6NrzcKXAI0E/lYC8YhfwpyllScqVEvAI3J2QgJZWYgrX+1qGI+SQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/auth/node_modules/@firebase/logger": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.4.tgz",
+      "integrity": "sha512-mH0PEh1zoXGnaR8gD1DeGeNZtWFKbnz9hDO91dIml3iou1gpOnLqXQ2dJfB71dj6dpmUjcQ6phY3ZZJbjErr9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/auth/node_modules/@firebase/util": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.12.1.tgz",
+      "integrity": "sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@firebase/component": {
       "version": "0.7.2",
@@ -51,6 +631,68 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/data-connect": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.3.10.tgz",
+      "integrity": "sha512-VMVk7zxIkgwlVQIWHOKFahmleIjiVFwFOjmakXPd/LDgaB/5vzwsB5DWIYo+3KhGxWpidQlR8geCIn39YflJIQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.6.18",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/data-connect/node_modules/@firebase/component": {
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.18.tgz",
+      "integrity": "sha512-n28kPCkE2dL2U28fSxZJjzPPVpKsQminJ6NrzcKXAI0E/lYC8YhfwpyllScqVEvAI3J2QgJZWYgrX+1qGI+SQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/data-connect/node_modules/@firebase/logger": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.4.tgz",
+      "integrity": "sha512-mH0PEh1zoXGnaR8gD1DeGeNZtWFKbnz9hDO91dIml3iou1gpOnLqXQ2dJfB71dj6dpmUjcQ6phY3ZZJbjErr9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/data-connect/node_modules/@firebase/util": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.12.1.tgz",
+      "integrity": "sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@firebase/database": {
@@ -98,6 +740,368 @@
         "@firebase/util": "1.15.0"
       }
     },
+    "node_modules/@firebase/firestore": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.8.0.tgz",
+      "integrity": "sha512-QSRk+Q1/CaabKyqn3C32KSFiOdZpSqI9rpLK5BHPcooElumOBooPFa6YkDdiT+/KhJtel36LdAacha9BptMj2A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/component": "0.6.18",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.12.1",
+        "@firebase/webchannel-wrapper": "1.0.3",
+        "@grpc/grpc-js": "~1.9.0",
+        "@grpc/proto-loader": "^0.7.8",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-compat": {
+      "version": "0.3.53",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.53.tgz",
+      "integrity": "sha512-qI3yZL8ljwAYWrTousWYbemay2YZa+udLWugjdjju2KODWtLG94DfO4NALJgPLv8CVGcDHNFXoyQexdRA0Cz8Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/component": "0.6.18",
+        "@firebase/firestore": "4.8.0",
+        "@firebase/firestore-types": "3.0.3",
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-compat/node_modules/@firebase/component": {
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.18.tgz",
+      "integrity": "sha512-n28kPCkE2dL2U28fSxZJjzPPVpKsQminJ6NrzcKXAI0E/lYC8YhfwpyllScqVEvAI3J2QgJZWYgrX+1qGI+SQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/firestore-compat/node_modules/@firebase/util": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.12.1.tgz",
+      "integrity": "sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/firestore-types": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.3.tgz",
+      "integrity": "sha512-hD2jGdiWRxB/eZWF89xcK9gF8wvENDJkzpVFb4aGkzfEaKxVRD1kjz1t1Wj8VZEp2LCB53Yx1zD8mrhQu87R6Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/firestore/node_modules/@firebase/component": {
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.18.tgz",
+      "integrity": "sha512-n28kPCkE2dL2U28fSxZJjzPPVpKsQminJ6NrzcKXAI0E/lYC8YhfwpyllScqVEvAI3J2QgJZWYgrX+1qGI+SQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/firestore/node_modules/@firebase/logger": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.4.tgz",
+      "integrity": "sha512-mH0PEh1zoXGnaR8gD1DeGeNZtWFKbnz9hDO91dIml3iou1gpOnLqXQ2dJfB71dj6dpmUjcQ6phY3ZZJbjErr9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/firestore/node_modules/@firebase/util": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.12.1.tgz",
+      "integrity": "sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/firestore/node_modules/@grpc/grpc-js": {
+      "version": "1.9.15",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.15.tgz",
+      "integrity": "sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.8",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "node_modules/@firebase/functions": {
+      "version": "0.12.9",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.12.9.tgz",
+      "integrity": "sha512-FG95w6vjbUXN84Ehezc2SDjGmGq225UYbHrb/ptkRT7OTuCiQRErOQuyt1jI1tvcDekdNog+anIObihNFz79Lg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.6.18",
+        "@firebase/messaging-interop-types": "0.2.3",
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-compat": {
+      "version": "0.3.26",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.3.26.tgz",
+      "integrity": "sha512-A798/6ff5LcG2LTWqaGazbFYnjBW8zc65YfID/en83ALmkhu2b0G8ykvQnLtakbV9ajrMYPn7Yc/XcYsZIUsjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/component": "0.6.18",
+        "@firebase/functions": "0.12.9",
+        "@firebase/functions-types": "0.6.3",
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-compat/node_modules/@firebase/component": {
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.18.tgz",
+      "integrity": "sha512-n28kPCkE2dL2U28fSxZJjzPPVpKsQminJ6NrzcKXAI0E/lYC8YhfwpyllScqVEvAI3J2QgJZWYgrX+1qGI+SQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/functions-compat/node_modules/@firebase/util": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.12.1.tgz",
+      "integrity": "sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/functions-types": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.3.tgz",
+      "integrity": "sha512-EZoDKQLUHFKNx6VLipQwrSMh01A1SaL3Wg6Hpi//x6/fJ6Ee4hrAeswK99I5Ht8roiniKHw4iO0B1Oxj5I4plg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true
+    },
+    "node_modules/@firebase/functions/node_modules/@firebase/component": {
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.18.tgz",
+      "integrity": "sha512-n28kPCkE2dL2U28fSxZJjzPPVpKsQminJ6NrzcKXAI0E/lYC8YhfwpyllScqVEvAI3J2QgJZWYgrX+1qGI+SQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/functions/node_modules/@firebase/util": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.12.1.tgz",
+      "integrity": "sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/installations": {
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.18.tgz",
+      "integrity": "sha512-NQ86uGAcvO8nBRwVltRL9QQ4Reidc/3whdAasgeWCPIcrhOKDuNpAALa6eCVryLnK14ua2DqekCOX5uC9XbU/A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/component": "0.6.18",
+        "@firebase/util": "1.12.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-compat": {
+      "version": "0.2.18",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.18.tgz",
+      "integrity": "sha512-aLFohRpJO5kKBL/XYL4tN+GdwEB/Q6Vo9eZOM/6Kic7asSUgmSfGPpGUZO1OAaSRGwF4Lqnvi1f/f9VZnKzChw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/component": "0.6.18",
+        "@firebase/installations": "0.6.18",
+        "@firebase/installations-types": "0.5.3",
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-compat/node_modules/@firebase/component": {
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.18.tgz",
+      "integrity": "sha512-n28kPCkE2dL2U28fSxZJjzPPVpKsQminJ6NrzcKXAI0E/lYC8YhfwpyllScqVEvAI3J2QgJZWYgrX+1qGI+SQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/installations-compat/node_modules/@firebase/util": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.12.1.tgz",
+      "integrity": "sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/installations-types": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.3.tgz",
+      "integrity": "sha512-2FJI7gkLqIE0iYsNQ1P751lO3hER+Umykel+TkLwHj6plzWVxqvfclPUZhcKFVQObqloEBTmpi2Ozn7EkCABAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "peerDependencies": {
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations/node_modules/@firebase/component": {
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.18.tgz",
+      "integrity": "sha512-n28kPCkE2dL2U28fSxZJjzPPVpKsQminJ6NrzcKXAI0E/lYC8YhfwpyllScqVEvAI3J2QgJZWYgrX+1qGI+SQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/installations/node_modules/@firebase/util": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.12.1.tgz",
+      "integrity": "sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@firebase/logger": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.0.tgz",
@@ -108,6 +1112,502 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/messaging": {
+      "version": "0.12.22",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.22.tgz",
+      "integrity": "sha512-GJcrPLc+Hu7nk+XQ70Okt3M1u1eRr2ZvpMbzbc54oTPJZySHcX9ccZGVFcsZbSZ6o1uqumm8Oc7OFkD3Rn1/og==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/component": "0.6.18",
+        "@firebase/installations": "0.6.18",
+        "@firebase/messaging-interop-types": "0.2.3",
+        "@firebase/util": "1.12.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-compat": {
+      "version": "0.2.22",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.22.tgz",
+      "integrity": "sha512-5ZHtRnj6YO6f/QPa/KU6gryjmX4Kg33Kn4gRpNU6M1K47Gm8kcQwPkX7erRUYEH1mIWptfvjvXMHWoZaWjkU7A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/component": "0.6.18",
+        "@firebase/messaging": "0.12.22",
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-compat/node_modules/@firebase/component": {
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.18.tgz",
+      "integrity": "sha512-n28kPCkE2dL2U28fSxZJjzPPVpKsQminJ6NrzcKXAI0E/lYC8YhfwpyllScqVEvAI3J2QgJZWYgrX+1qGI+SQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/messaging-compat/node_modules/@firebase/util": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.12.1.tgz",
+      "integrity": "sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/messaging-interop-types": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.3.tgz",
+      "integrity": "sha512-xfzFaJpzcmtDjycpDeCUj0Ge10ATFi/VHVIvEEjDNc3hodVBQADZ7BWQU7CuFpjSHE+eLuBI13z5F/9xOoGX8Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true
+    },
+    "node_modules/@firebase/messaging/node_modules/@firebase/component": {
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.18.tgz",
+      "integrity": "sha512-n28kPCkE2dL2U28fSxZJjzPPVpKsQminJ6NrzcKXAI0E/lYC8YhfwpyllScqVEvAI3J2QgJZWYgrX+1qGI+SQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/messaging/node_modules/@firebase/util": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.12.1.tgz",
+      "integrity": "sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/performance": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.7.tgz",
+      "integrity": "sha512-JTlTQNZKAd4+Q5sodpw6CN+6NmwbY72av3Lb6wUKTsL7rb3cuBIhQSrslWbVz0SwK3x0ZNcqX24qtRbwKiv+6w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/component": "0.6.18",
+        "@firebase/installations": "0.6.18",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0",
+        "web-vitals": "^4.2.4"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-compat": {
+      "version": "0.2.20",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.20.tgz",
+      "integrity": "sha512-XkFK5NmOKCBuqOKWeRgBUFZZGz9SzdTZp4OqeUg+5nyjapTiZ4XoiiUL8z7mB2q+63rPmBl7msv682J3rcDXIQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/component": "0.6.18",
+        "@firebase/logger": "0.4.4",
+        "@firebase/performance": "0.7.7",
+        "@firebase/performance-types": "0.2.3",
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-compat/node_modules/@firebase/component": {
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.18.tgz",
+      "integrity": "sha512-n28kPCkE2dL2U28fSxZJjzPPVpKsQminJ6NrzcKXAI0E/lYC8YhfwpyllScqVEvAI3J2QgJZWYgrX+1qGI+SQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/performance-compat/node_modules/@firebase/logger": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.4.tgz",
+      "integrity": "sha512-mH0PEh1zoXGnaR8gD1DeGeNZtWFKbnz9hDO91dIml3iou1gpOnLqXQ2dJfB71dj6dpmUjcQ6phY3ZZJbjErr9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/performance-compat/node_modules/@firebase/util": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.12.1.tgz",
+      "integrity": "sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/performance-types": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.3.tgz",
+      "integrity": "sha512-IgkyTz6QZVPAq8GSkLYJvwSLr3LS9+V6vNPQr0x4YozZJiLF5jYixj0amDtATf1X0EtYHqoPO48a9ija8GocxQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true
+    },
+    "node_modules/@firebase/performance/node_modules/@firebase/component": {
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.18.tgz",
+      "integrity": "sha512-n28kPCkE2dL2U28fSxZJjzPPVpKsQminJ6NrzcKXAI0E/lYC8YhfwpyllScqVEvAI3J2QgJZWYgrX+1qGI+SQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/performance/node_modules/@firebase/logger": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.4.tgz",
+      "integrity": "sha512-mH0PEh1zoXGnaR8gD1DeGeNZtWFKbnz9hDO91dIml3iou1gpOnLqXQ2dJfB71dj6dpmUjcQ6phY3ZZJbjErr9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/performance/node_modules/@firebase/util": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.12.1.tgz",
+      "integrity": "sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/remote-config": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.6.5.tgz",
+      "integrity": "sha512-fU0c8HY0vrVHwC+zQ/fpXSqHyDMuuuglV94VF6Yonhz8Fg2J+KOowPGANM0SZkLvVOYpTeWp3ZmM+F6NjwWLnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/component": "0.6.18",
+        "@firebase/installations": "0.6.18",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat": {
+      "version": "0.2.18",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.18.tgz",
+      "integrity": "sha512-YiETpldhDy7zUrnS8e+3l7cNs0sL7+tVAxvVYU0lu7O+qLHbmdtAxmgY+wJqWdW2c9nDvBFec7QiF58pEUu0qQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/component": "0.6.18",
+        "@firebase/logger": "0.4.4",
+        "@firebase/remote-config": "0.6.5",
+        "@firebase/remote-config-types": "0.4.0",
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat/node_modules/@firebase/component": {
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.18.tgz",
+      "integrity": "sha512-n28kPCkE2dL2U28fSxZJjzPPVpKsQminJ6NrzcKXAI0E/lYC8YhfwpyllScqVEvAI3J2QgJZWYgrX+1qGI+SQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat/node_modules/@firebase/logger": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.4.tgz",
+      "integrity": "sha512-mH0PEh1zoXGnaR8gD1DeGeNZtWFKbnz9hDO91dIml3iou1gpOnLqXQ2dJfB71dj6dpmUjcQ6phY3ZZJbjErr9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat/node_modules/@firebase/util": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.12.1.tgz",
+      "integrity": "sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/remote-config-types": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.4.0.tgz",
+      "integrity": "sha512-7p3mRE/ldCNYt8fmWMQ/MSGRmXYlJ15Rvs9Rk17t8p0WwZDbeK7eRmoI1tvCPaDzn9Oqh+yD6Lw+sGLsLg4kKg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true
+    },
+    "node_modules/@firebase/remote-config/node_modules/@firebase/component": {
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.18.tgz",
+      "integrity": "sha512-n28kPCkE2dL2U28fSxZJjzPPVpKsQminJ6NrzcKXAI0E/lYC8YhfwpyllScqVEvAI3J2QgJZWYgrX+1qGI+SQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/remote-config/node_modules/@firebase/logger": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.4.tgz",
+      "integrity": "sha512-mH0PEh1zoXGnaR8gD1DeGeNZtWFKbnz9hDO91dIml3iou1gpOnLqXQ2dJfB71dj6dpmUjcQ6phY3ZZJbjErr9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/remote-config/node_modules/@firebase/util": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.12.1.tgz",
+      "integrity": "sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/rules-unit-testing": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@firebase/rules-unit-testing/-/rules-unit-testing-4.0.1.tgz",
+      "integrity": "sha512-Vu8iMLP+dO9hCAqUCitWZQdORyM6CxucilRZtleeTZd5bejZmyOiaBPwYm3NOYG6025ac99CEeA+ETmJRxa9zg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "firebase": "^11.0.0"
+      }
+    },
+    "node_modules/@firebase/storage": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.13.14.tgz",
+      "integrity": "sha512-xTq5ixxORzx+bfqCpsh+o3fxOsGoDjC1nO0Mq2+KsOcny3l7beyBhP/y1u5T6mgsFQwI1j6oAkbT5cWdDBx87g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/component": "0.6.18",
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-compat": {
+      "version": "0.3.24",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.3.24.tgz",
+      "integrity": "sha512-XHn2tLniiP7BFKJaPZ0P8YQXKiVJX+bMyE2j2YWjYfaddqiJnROJYqSomwW6L3Y+gZAga35ONXUJQju6MB6SOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/component": "0.6.18",
+        "@firebase/storage": "0.13.14",
+        "@firebase/storage-types": "0.8.3",
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-compat/node_modules/@firebase/component": {
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.18.tgz",
+      "integrity": "sha512-n28kPCkE2dL2U28fSxZJjzPPVpKsQminJ6NrzcKXAI0E/lYC8YhfwpyllScqVEvAI3J2QgJZWYgrX+1qGI+SQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/storage-compat/node_modules/@firebase/util": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.12.1.tgz",
+      "integrity": "sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/storage-types": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.3.tgz",
+      "integrity": "sha512-+Muk7g9uwngTpd8xn9OdF/D48uiQ7I1Fae7ULsWPuKoCH3HU7bfFPhxtJYzyhjdniowhuDpQcfPmuNRAqZEfvg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/storage/node_modules/@firebase/component": {
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.18.tgz",
+      "integrity": "sha512-n28kPCkE2dL2U28fSxZJjzPPVpKsQminJ6NrzcKXAI0E/lYC8YhfwpyllScqVEvAI3J2QgJZWYgrX+1qGI+SQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/storage/node_modules/@firebase/util": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.12.1.tgz",
+      "integrity": "sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@firebase/util": {
@@ -122,6 +1622,14 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/@firebase/webchannel-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.3.tgz",
+      "integrity": "sha512-2xCRM9q9FlzGZCdgDMJwc0gyUkWFtkosy7Xxr6sFgQwn+wMNIWd7xIvYNauU1r64B5L5rsGKy/n9TKJ0aAFeqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@google-cloud/firestore": {
       "version": "7.11.6",
@@ -291,8 +1799,8 @@
       "version": "0.7.15",
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
       "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
@@ -605,8 +2113,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -615,8 +2123,8 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -761,8 +2269,8 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "devOptional": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -776,8 +2284,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -789,8 +2297,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -951,8 +2459,8 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -1023,8 +2531,8 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -1211,6 +2719,44 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/firebase": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-11.10.0.tgz",
+      "integrity": "sha512-nKBXoDzF0DrXTBQJlZa+sbC5By99ysYU1D6PkMRYknm0nCW7rJly47q492Ht7Ndz5MeYSBuboKuhS1e6mFC03w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/ai": "1.4.1",
+        "@firebase/analytics": "0.10.17",
+        "@firebase/analytics-compat": "0.2.23",
+        "@firebase/app": "0.13.2",
+        "@firebase/app-check": "0.10.1",
+        "@firebase/app-check-compat": "0.3.26",
+        "@firebase/app-compat": "0.4.2",
+        "@firebase/app-types": "0.9.3",
+        "@firebase/auth": "1.10.8",
+        "@firebase/auth-compat": "0.5.28",
+        "@firebase/data-connect": "0.3.10",
+        "@firebase/database": "1.0.20",
+        "@firebase/database-compat": "2.0.11",
+        "@firebase/firestore": "4.8.0",
+        "@firebase/firestore-compat": "0.3.53",
+        "@firebase/functions": "0.12.9",
+        "@firebase/functions-compat": "0.3.26",
+        "@firebase/installations": "0.6.18",
+        "@firebase/installations-compat": "0.2.18",
+        "@firebase/messaging": "0.12.22",
+        "@firebase/messaging-compat": "0.2.22",
+        "@firebase/performance": "0.7.7",
+        "@firebase/performance-compat": "0.2.20",
+        "@firebase/remote-config": "0.6.5",
+        "@firebase/remote-config-compat": "0.2.18",
+        "@firebase/storage": "0.13.14",
+        "@firebase/storage-compat": "0.3.24",
+        "@firebase/util": "1.12.1"
+      }
+    },
     "node_modules/firebase-admin": {
       "version": "13.7.0",
       "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.7.0.tgz",
@@ -1256,6 +2802,101 @@
       },
       "peerDependencies": {
         "firebase-admin": "^11.10.0 || ^12.0.0 || ^13.0.0"
+      }
+    },
+    "node_modules/firebase/node_modules/@firebase/component": {
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.18.tgz",
+      "integrity": "sha512-n28kPCkE2dL2U28fSxZJjzPPVpKsQminJ6NrzcKXAI0E/lYC8YhfwpyllScqVEvAI3J2QgJZWYgrX+1qGI+SQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/firebase/node_modules/@firebase/database": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.20.tgz",
+      "integrity": "sha512-H9Rpj1pQ1yc9+4HQOotFGLxqAXwOzCHsRSRjcQFNOr8lhUt6LeYjf0NSRL04sc4X0dWe8DsCvYKxMYvFG/iOJw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.6.18",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.12.1",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/firebase/node_modules/@firebase/database-compat": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.0.11.tgz",
+      "integrity": "sha512-itEsHARSsYS95+udF/TtIzNeQ0Uhx4uIna0sk4E0wQJBUnLc/G1X6D7oRljoOuwwCezRLGvWBRyNrugv/esOEw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/component": "0.6.18",
+        "@firebase/database": "1.0.20",
+        "@firebase/database-types": "1.0.15",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.12.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/firebase/node_modules/@firebase/database-types": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.15.tgz",
+      "integrity": "sha512-XWHJ0VUJ0k2E9HDMlKxlgy/ZuTa9EvHCGLjaKSUvrQnwhgZuRU5N3yX6SZ+ftf2hTzZmfRkv+b3QRvGg40bKNw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/app-types": "0.9.3",
+        "@firebase/util": "1.12.1"
+      }
+    },
+    "node_modules/firebase/node_modules/@firebase/logger": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.4.tgz",
+      "integrity": "sha512-mH0PEh1zoXGnaR8gD1DeGeNZtWFKbnz9hDO91dIml3iou1gpOnLqXQ2dJfB71dj6dpmUjcQ6phY3ZZJbjErr9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/firebase/node_modules/@firebase/util": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.12.1.tgz",
+      "integrity": "sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/form-data": {
@@ -1403,8 +3044,8 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "devOptional": true,
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -1795,6 +3436,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -1814,8 +3463,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -1948,8 +3597,8 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
@@ -2370,8 +4019,8 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2614,8 +4263,8 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -2629,8 +4278,8 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -2852,6 +4501,14 @@
         "node": ">= 8"
       }
     },
+    "node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -2897,8 +4554,8 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -2922,8 +4579,8 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "devOptional": true,
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": ">=10"
       }
@@ -2938,8 +4595,8 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -2957,8 +4614,8 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "devOptional": true,
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": ">=12"
       }

--- a/CineMate/functions/package.json
+++ b/CineMate/functions/package.json
@@ -10,6 +10,8 @@
     "build": "tsc",
     "clean": "rm -rf lib",
     "lint": "tsc --noEmit",
+    "test:rules:local": "npm run build && node --test lib/rules/firestore.rules.test.js",
+    "test:rules": "firebase emulators:exec --only firestore \"npm run test:rules:local\"",
     "serve": "npm run build && firebase emulators:start --only functions",
     "deploy": "firebase deploy --only functions"
   },
@@ -18,6 +20,7 @@
     "firebase-functions": "^6.0.0"
   },
   "devDependencies": {
+    "@firebase/rules-unit-testing": "^4.0.1",
     "typescript": "^5.9.0"
   }
 }

--- a/CineMate/functions/src/rules/firestore.rules.test.ts
+++ b/CineMate/functions/src/rules/firestore.rules.test.ts
@@ -1,0 +1,172 @@
+import { readFile } from "node:fs/promises"
+import { resolve } from "node:path"
+import { after, afterEach, before, test } from "node:test"
+
+import {
+  assertFails,
+  assertSucceeds,
+  initializeTestEnvironment,
+  type RulesTestEnvironment,
+} from "@firebase/rules-unit-testing"
+import { doc, setDoc, serverTimestamp } from "firebase/firestore"
+
+const CURRENT_TERMS_VERSION = "2026-04-10"
+
+let testEnv: RulesTestEnvironment
+
+function ownerDb(uid: string) {
+  return testEnv.authenticatedContext(uid).firestore()
+}
+
+async function seedTermsAcceptance(
+  uid: string,
+  {
+    termsVersion = CURRENT_TERMS_VERSION,
+    includeAcceptedAt = true,
+    appVersion = "1.0.0",
+  }: {
+    termsVersion?: string
+    includeAcceptedAt?: boolean
+    appVersion?: string
+  } = {}
+) {
+  await testEnv.withSecurityRulesDisabled(async (context) => {
+    const db = context.firestore()
+    const data: Record<string, unknown> = {
+      termsVersion,
+      appVersion,
+    }
+    if (includeAcceptedAt) {
+      data.acceptedAt = new Date("2026-04-10T00:00:00Z")
+    }
+
+    await setDoc(doc(db, "users", uid), data, { merge: true })
+  })
+}
+
+before(async () => {
+  const rules = await readFile(resolve(process.cwd(), "../firestore.rules"), "utf8")
+  testEnv = await initializeTestEnvironment({
+    projectId: `cinemate-rules-${Date.now()}`,
+    firestore: {
+      rules,
+      host: "127.0.0.1",
+      port: 8080,
+    },
+  })
+})
+
+afterEach(async () => {
+  await testEnv.clearFirestore()
+})
+
+after(async () => {
+  await testEnv.cleanup()
+})
+
+test("owner can write acceptance metadata on own user document", async () => {
+  const uid = "alice"
+  const db = ownerDb(uid)
+
+  await assertSucceeds(
+    setDoc(
+      doc(db, "users", uid),
+      {
+        termsVersion: CURRENT_TERMS_VERSION,
+        acceptedAt: serverTimestamp(),
+        appVersion: "2.4.1",
+      },
+      { merge: true }
+    )
+  )
+})
+
+test("owner cannot write favorites before accepting current terms", async () => {
+  const uid = "alice"
+  const db = ownerDb(uid)
+
+  await assertFails(
+    setDoc(
+      doc(db, "users", uid, "favorites", "1"),
+      {
+        id: 1,
+        title: "Movie A",
+        createdAt: serverTimestamp(),
+      },
+      { merge: true }
+    )
+  )
+})
+
+test("owner can write favorites after accepting current terms", async () => {
+  const uid = "alice"
+  await seedTermsAcceptance(uid)
+  const db = ownerDb(uid)
+
+  await assertSucceeds(
+    setDoc(
+      doc(db, "users", uid, "favorites", "1"),
+      {
+        id: 1,
+        title: "Movie A",
+        createdAt: serverTimestamp(),
+      },
+      { merge: true }
+    )
+  )
+})
+
+test("owner cannot write favorites when accepted terms version is stale", async () => {
+  const uid = "alice"
+  await seedTermsAcceptance(uid, { termsVersion: "2026-01-01" })
+  const db = ownerDb(uid)
+
+  await assertFails(
+    setDoc(
+      doc(db, "users", uid, "favorites", "1"),
+      {
+        id: 1,
+        title: "Movie A",
+        createdAt: serverTimestamp(),
+      },
+      { merge: true }
+    )
+  )
+})
+
+test("owner cannot write favorites when acceptedAt is missing", async () => {
+  const uid = "alice"
+  await seedTermsAcceptance(uid, { includeAcceptedAt: false })
+  const db = ownerDb(uid)
+
+  await assertFails(
+    setDoc(
+      doc(db, "users", uid, "favorites", "1"),
+      {
+        id: 1,
+        title: "Movie A",
+        createdAt: serverTimestamp(),
+      },
+      { merge: true }
+    )
+  )
+})
+
+test("non owner cannot write another user's subtree even when terms are accepted", async () => {
+  const ownerUid = "alice"
+  const attackerUid = "mallory"
+  await seedTermsAcceptance(ownerUid)
+  const attackerDb = ownerDb(attackerUid)
+
+  await assertFails(
+    setDoc(
+      doc(attackerDb, "users", ownerUid, "favorites", "1"),
+      {
+        id: 1,
+        title: "Movie A",
+        createdAt: serverTimestamp(),
+      },
+      { merge: true }
+    )
+  )
+})


### PR DESCRIPTION
## What changed
- Added `TermsContent.currentVersion` and updated terms text with current TMDB notice and links
- Refactored `TermsSheet` into smaller parts
- Added `TermsHeader`, `TermsBlockView`, and `TermsMarkdownParser`
- Registered new sheet files in Xcode project build phases
- Extended auth signup flow to store terms acceptance metadata
- Saved `termsVersion`, `acceptedAt`, and optional `appVersion` in Firestore
- Added read and write APIs for terms acceptance in `FirebaseAuthService`
- Added legal state in `AuthViewModel` with outdated check and accept action
- Added Legal section in `AccountView` with
  - accepted version summary
  - outdated and up to date status
  - review gate before accept update
  - reviewed state and legal toasts
- Updated account toasts to consistent short English copy
- Added Firestore rules enforcement for user subcollection writes
  - owner only
  - requires accepted current terms version
  - requires `acceptedAt` timestamp
- Added Firestore Emulator rules tests in `functions/src/rules/firestore.rules.test.ts`
- Added rules test scripts and dependency in `functions/package.json`
- Updated `functions/README.md` with test command
- Updated `functions/package-lock.json` from dependency install