### PR TITLE
refactor(auth): clean up login flow

### DIFF
--- a/CineMate/CineMate.xcodeproj/project.pbxproj
+++ b/CineMate/CineMate.xcodeproj/project.pbxproj
@@ -259,6 +259,8 @@
 		9A1F1B412F01000100A1B2C3 /* SearchTestDoubles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1F1B3E2F01000100A1B2C3 /* SearchTestDoubles.swift */; };
 		9A1F1B422F01000100A1B2C3 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A1F1B432F01000100A1B2C3 /* XCTest.framework */; };
 		A1B2C3D52F70000100ABCDEF /* ChangeEmailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42F70000100ABCDEF /* ChangeEmailSheet.swift */; };
+		A1B2D0012F7600010010ABCD /* GoogleLegalAcceptanceSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2D0022F7600010010ABCD /* GoogleLegalAcceptanceSheet.swift */; };
+		A1B2D0032F7600010010ABCD /* DebugLoginCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2D0042F7600010010ABCD /* DebugLoginCredentials.swift */; };
 		B1C2D3002FA1000100A1A1A1 /* TermsMarkdownParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3032FA1000100A1A1A1 /* TermsMarkdownParser.swift */; };
 		B1C2D3012FA1000100A1A1A1 /* TermsBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3042FA1000100A1A1A1 /* TermsBlockView.swift */; };
 		B1C2D3022FA1000100A1A1A1 /* TermsHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3052FA1000100A1A1A1 /* TermsHeader.swift */; };
@@ -528,6 +530,8 @@
 		9A1F1B3E2F01000100A1B2C3 /* SearchTestDoubles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTestDoubles.swift; sourceTree = "<group>"; };
 		9A1F1B432F01000100A1B2C3 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		A1B2C3D42F70000100ABCDEF /* ChangeEmailSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeEmailSheet.swift; sourceTree = "<group>"; };
+		A1B2D0022F7600010010ABCD /* GoogleLegalAcceptanceSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleLegalAcceptanceSheet.swift; sourceTree = "<group>"; };
+		A1B2D0042F7600010010ABCD /* DebugLoginCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugLoginCredentials.swift; sourceTree = "<group>"; };
 		B1C2D3032FA1000100A1A1A1 /* TermsMarkdownParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsMarkdownParser.swift; sourceTree = "<group>"; };
 		B1C2D3042FA1000100A1A1A1 /* TermsBlockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsBlockView.swift; sourceTree = "<group>"; };
 		B1C2D3052FA1000100A1A1A1 /* TermsHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsHeader.swift; sourceTree = "<group>"; };
@@ -907,6 +911,7 @@
 			isa = PBXGroup;
 			children = (
 				032BAF812E53AFC7001077A8 /* LoginView.swift */,
+				A1B2D0022F7600010010ABCD /* GoogleLegalAcceptanceSheet.swift */,
 				0397B36F2E5517E400065408 /* CreateAccountView.swift */,
 				03CB4AAD2E1876500080EE84 /* AccountView.swift */,
 				A1B2C3D42F70000100ABCDEF /* ChangeEmailSheet.swift */,
@@ -1129,8 +1134,17 @@
 				0390F7DB2E5DE36400E89B82 /* ViewModels */,
 				0390F7DC2E5DE36F00E89B82 /* Components */,
 				03DCB0602E5603910071C3B2 /* PreviewData */,
+				A1B2D0052F7600010010ABCD /* Debug */,
 			);
 			path = Auth;
+			sourceTree = "<group>";
+		};
+		A1B2D0052F7600010010ABCD /* Debug */ = {
+			isa = PBXGroup;
+			children = (
+				A1B2D0042F7600010010ABCD /* DebugLoginCredentials.swift */,
+			);
+			path = Debug;
 			sourceTree = "<group>";
 		};
 		0390F7DB2E5DE36400E89B82 /* ViewModels */ = {
@@ -1792,6 +1806,8 @@
 				03FC25DD2E06A24000AACB5E /* MovieViewModel+Preview.swift in Sources */,
 				0397B3702E5517E400065408 /* CreateAccountView.swift in Sources */,
 				032BAF822E53AFC7001077A8 /* LoginView.swift in Sources */,
+				A1B2D0012F7600010010ABCD /* GoogleLegalAcceptanceSheet.swift in Sources */,
+				A1B2D0032F7600010010ABCD /* DebugLoginCredentials.swift in Sources */,
 				03BAD6A92E298A710035F1F5 /* PersonMetaInfoPreviewData.swift in Sources */,
 				03F3AD972E11E16500B63AA2 /* PersonInfoView+Previews.swift in Sources */,
 				031392032E1AAA0F0047ED6B /* PreviewFactory+Search.swift in Sources */,

--- a/CineMate/CineMate/CineMateApp.swift
+++ b/CineMate/CineMate/CineMateApp.swift
@@ -32,13 +32,13 @@ import AppIntents
 struct CineMate: App {
     // Global enum-based navigation (bound to `NavigationStack` in RootView)
     @StateObject private var navigator = AppNavigator()
-
+    
     // Lightweight global toast service
     @StateObject private var toastCenter = ToastCenter()
-
+    
     // Shared services (network/auth)
     private let authService: FirebaseAuthService
-
+    
     // Long-lived view models (owned by the App)
     @StateObject private var movieViewModel: MovieViewModel
     @StateObject private var castViewModel: CastViewModel
@@ -48,18 +48,18 @@ struct CineMate: App {
     @StateObject private var personViewModel: PersonViewModel
     @StateObject private var favoritePeopleViewModel: FavoritePeopleViewModel
     @StateObject private var authViewModel: AuthViewModel
-
+    
     /// Build the DI graph (services -> view models).
     /// `@StateObject` ensures each VM is created once and reused.
     init() {
         // Order is enforced once at app-level bootstrap.
         AppBootstrap.ensureConfigured()
-
+        
         let repo = MovieRepository()
         let auth = FirebaseAuthService()
         let authVM = AuthViewModel(service: auth)
         self.authService = auth
-
+        
         // Create VMs that depend on the shared services
         _movieViewModel          = StateObject(wrappedValue: MovieViewModel(repository: repo))
         _castViewModel           = StateObject(wrappedValue: CastViewModel(repository: repo))
@@ -77,7 +77,7 @@ struct CineMate: App {
             wrappedValue: FavoriteMoviesViewModel(authService: auth)
         )
     }
-
+    
     var body: some Scene {
         WindowGroup {
             appRoot
@@ -90,7 +90,7 @@ struct CineMate: App {
                 .handleGoogleSignInURL()
         }
     }
-
+    
     @ViewBuilder
     private var appRoot: some View {
         switch authGateState {
@@ -100,11 +100,11 @@ struct CineMate: App {
             SignedOutRootView(authService: authService, onSignedIn: handleSignIn)
         }
     }
-
+    
     private var authGateState: AuthGateState {
         authViewModel.currentUID == nil ? .signedOut : .signedIn
     }
-
+    
     private var signedInRoot: some View {
         RootView(
             movieVM: movieViewModel,
@@ -118,7 +118,7 @@ struct CineMate: App {
             authService: authService
         )
     }
-
+    
     private func handleSignIn(_ uid: String) {
         authViewModel.errorMessage = nil
         authViewModel.isAuthenticating = false
@@ -126,18 +126,18 @@ struct CineMate: App {
             authViewModel.currentUID = uid
         }
     }
-
+    
     private func handleSessionTransition(from oldUID: String?, to newUID: String?) {
         let fromSignedIn = oldUID != nil
         let toSignedIn = newUID != nil
         guard fromSignedIn != toSignedIn else { return }
-
+        
         let fromState = fromSignedIn ? "signedIn" : "signedOut"
         let toState = toSignedIn ? "signedIn" : "signedOut"
         log("auth gate transition \(fromState) -> \(toState)")
-        navigator.reset(reason: "auth gate transition \(fromState) -> \(toState)")
+        navigator.resetDeferred(reason: "auth gate transition \(fromState) -> \(toState)")
     }
-
+    
     private func log(_ message: String) {
 #if DEBUG
         print("[App][Nav][AuthGate] \(message)")
@@ -158,16 +158,16 @@ private struct SignedOutRootView: View {
     @EnvironmentObject private var toastCenter: ToastCenter
     @State private var path: [SignedOutRoute] = []
     @StateObject private var loginViewModel: LoginViewModel
-
+    
     private let authService: FirebaseAuthService
-
+    
     init(authService: FirebaseAuthService, onSignedIn: @escaping (String) -> Void) {
         self.authService = authService
         _loginViewModel = StateObject(
             wrappedValue: LoginViewModel(service: authService, onSuccess: onSignedIn)
         )
     }
-
+    
     var body: some View {
         NavigationStack(path: $path) {
             LoginView(
@@ -198,25 +198,25 @@ private struct SignedOutRootView: View {
 private enum AppBootstrap {
     private static let lock = NSLock()
     private static var didRun = false
-
+    
     static func ensureConfigured() {
         guard !ProcessInfo.processInfo.isPreview else { return }
-
+        
         lock.lock()
         defer { lock.unlock() }
-
+        
         guard !didRun else {
             log("bootstrap skipped (already completed)")
             return
         }
-
+        
         log("bootstrap start")
         FirebaseBootstrap.ensureConfigured()
         GoogleSignInBootstrap.ensureConfigured()
         didRun = true
         log("bootstrap complete")
     }
-
+    
     private static func log(_ message: String) {
 #if DEBUG
         print("[App][Bootstrap] \(message)")

--- a/CineMate/CineMate/Core/Navigation/AppNavigator.swift
+++ b/CineMate/CineMate/Core/Navigation/AppNavigator.swift
@@ -15,6 +15,7 @@ import SwiftUI
 final class AppNavigator: ObservableObject {
     /// The current navigation path that SwiftUI observes.
     @Published var path: [AppRoute] = []
+    private var deferredResetTask: Task<Void, Never>?
     
     // MARK: - Public navigation helpers
     
@@ -62,6 +63,19 @@ final class AppNavigator: ObservableObject {
     /// Clear the entire navigation stack (e.g., when switching tabs).
     func reset(reason: String = "manual") {
         replacePath(with: [], reason: reason)
+    }
+    
+    /// Clears the navigation stack on the next main-actor turn.
+    /// This avoids mutating `NavigationStack` state in the same frame as
+    /// higher-level root view transitions such as auth-gate swaps.
+    func resetDeferred(reason: String = "manual") {
+        deferredResetTask?.cancel()
+        deferredResetTask = Task { @MainActor [weak self] in
+            await Task.yield()
+            guard let self, !Task.isCancelled else { return }
+            self.reset(reason: reason)
+            self.deferredResetTask = nil
+        }
     }
     
     /// Replace the entire navigation path with a new one.

--- a/CineMate/CineMate/Design/AuthTheme.swift
+++ b/CineMate/CineMate/Design/AuthTheme.swift
@@ -14,12 +14,13 @@ enum AuthTheme {
     static let curtainBottom = Color.tmdbBlue
     static let popcorn = Color.appPrimaryAction
     static let curtainContrastOverlay = Color.black.opacity(0.16)
-    
+
     static let cardStroke = Color.white.opacity(0.16)
     static let iconOnCurtain = Color.white.opacity(0.95)
     static let textOnCurtainPrimary = Color.white.opacity(0.97)
     static let textOnCurtainSecondary = Color.white.opacity(0.90)
     static let linkOnCurtain = Color.white.opacity(0.98)
+    static let warningOnCurtain = Color(red: 1.0, green: 0.84, blue: 0.42)
 }
 
 /// Shared spacing, corner-radius and size tokens used by reusable UI components.
@@ -32,14 +33,14 @@ enum SharedUI {
         static let xLarge: CGFloat = 20
         static let xxLarge: CGFloat = 24
     }
-    
+
     enum Radius {
         static let small: CGFloat = 8
         static let medium: CGFloat = 12
         static let large: CGFloat = 14
         static let sheet: CGFloat = 16
     }
-    
+
     enum Size {
         static let iconButton: CGFloat = 32
         static let fieldIconTapTarget: CGFloat = 32
@@ -48,7 +49,7 @@ enum SharedUI {
         static let posterGrid = CGSize(width: 120, height: 180)
         static let posterLarge = CGSize(width: 300, height: 450)
     }
-    
+
     enum Overlay {
         static let cardMaxWidth: CGFloat = 320
         static let cardPadding: CGFloat = 18
@@ -62,7 +63,7 @@ extension Color {
     static let tmdbNavy = Color("Brand/TMDB/Navy")
     static let tmdbBlue = Color("Brand/TMDB/Blue")
     static let tmdbGreen = Color("Brand/TMDB/Green")
-    
+
     // Semantic app tokens
     static let appBackground = Color("App/Background")
     static let appSurface = Color("App/Surface")

--- a/CineMate/CineMate/Features/Account/Auth/Components/AuthErrorBlock.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Components/AuthErrorBlock.swift
@@ -10,31 +10,35 @@ import SwiftUI
 /// Small error view for auth screens.
 /// It can also show a resend verification action.
 struct AuthErrorBlock: View {
-
+    
     /// Error text.
     let message: String
-
+    
     /// Shows resend button when true.
     var showResend: Bool = false
-
+    
     /// Called when user taps resend.
     var onResend: () -> Void = {}
-
+    
     var body: some View {
-        VStack(spacing: 8) {
+        VStack(alignment: .leading, spacing: SharedUI.Spacing.small) {
             Text(message)
                 .font(.footnote)
-                .foregroundStyle(Color.appDestructive)
-                .multilineTextAlignment(.center)
-
+                .foregroundStyle(AuthTheme.warningOnCurtain)
+                .multilineTextAlignment(.leading)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.leading, SharedUI.Spacing.medium)
+            
             if showResend {
                 Button("Resend verification email") {
                     onResend()
                 }
                 .buttonStyle(.bordered)
                 .tint(.appPrimaryAction)
+                .padding(.leading, SharedUI.Spacing.medium)
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .transition(.opacity)
     }
 }
@@ -42,7 +46,7 @@ struct AuthErrorBlock: View {
 #Preview {
     VStack(spacing: 16) {
         AuthErrorBlock(message: "Wrong email or password")
-
+        
         AuthErrorBlock(
             message: "Please verify your email",
             showResend: true

--- a/CineMate/CineMate/Features/Account/Auth/Components/ValidationMessageView.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Components/ValidationMessageView.swift
@@ -30,8 +30,9 @@ struct ValidationMessageView: View {
         Text(message)
             .font(.footnote)
             .foregroundStyle(textColor)
-            .multilineTextAlignment(.center)
-            .padding(.horizontal)
+            .multilineTextAlignment(.leading)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.leading, SharedUI.Spacing.medium)
             .padding(.top, 4)
     }
 }

--- a/CineMate/CineMate/Features/Account/Auth/Debug/DebugLoginCredentials.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Debug/DebugLoginCredentials.swift
@@ -1,0 +1,23 @@
+//
+//  DebugLoginCredentials.swift
+//  CineMate
+//
+//  Created by Nicholas Samuelsson Jeria on 2026-05-22.
+//
+
+import Foundation
+
+#if DEBUG
+enum DebugLoginCredentials {
+    private static let environment = ProcessInfo.processInfo.environment
+
+    static var email: String? { sanitize(environment["DEBUG_LOGIN_EMAIL"]) }
+    static var password: String? { sanitize(environment["DEBUG_LOGIN_PASSWORD"]) }
+
+    private static func sanitize(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+#endif

--- a/CineMate/CineMate/Features/Account/Auth/Views/GoogleLegalAcceptanceSheet.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Views/GoogleLegalAcceptanceSheet.swift
@@ -1,0 +1,165 @@
+//
+//  GoogleLegalAcceptanceSheet.swift
+//  CineMate
+//
+//  Created by Nicholas Samuelsson Jeria on 2026-05-22.
+//
+
+import SwiftUI
+
+struct GoogleLegalAcceptanceSheet: View {
+    @ObservedObject var viewModel: LoginViewModel
+    @State private var activeLegalSheet: LegalSheet?
+
+    var body: some View {
+        NavigationStack {
+            VStack(alignment: .leading, spacing: 18) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Image(systemName: "checkmark.shield")
+                        .font(.system(size: 30, weight: .semibold))
+                        .foregroundStyle(AuthTheme.popcorn)
+                    Text("Review before continuing")
+                        .font(.title3.weight(.bold))
+                        .foregroundStyle(AuthTheme.textOnCurtainPrimary)
+                    Text("Accept the same terms and privacy policy used for email accounts to finish Google sign-in.")
+                        .font(.callout)
+                        .foregroundStyle(AuthTheme.textOnCurtainSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                legalConsentRow(
+                    title: "I accept the Terms of Service",
+                    linkTitle: "View terms",
+                    isAccepted: $viewModel.acceptedGoogleTerms,
+                    helperText: viewModel.googleTermsHelperText,
+                    onLinkTap: { activeLegalSheet = .terms }
+                )
+
+                legalConsentRow(
+                    title: "I accept the Privacy Policy",
+                    linkTitle: "View privacy policy",
+                    isAccepted: $viewModel.acceptedGooglePrivacyPolicy,
+                    helperText: viewModel.googlePrivacyPolicyHelperText,
+                    onLinkTap: { activeLegalSheet = .privacyPolicy }
+                )
+
+                if let message = viewModel.errorMessage {
+                    AuthErrorBlock(message: message)
+                }
+
+                Button {
+                    Task { await viewModel.acceptGoogleLegalTerms() }
+                } label: {
+                    Text("Continue")
+                        .fontWeight(.semibold)
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.pillWhite)
+                .controlSize(.large)
+                .frame(height: 48)
+                .disabled(viewModel.isAuthenticating)
+
+                Spacer(minLength: 0)
+            }
+            .padding(20)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            .background(
+                LinearGradient(
+                    colors: [AuthTheme.curtainTop, AuthTheme.curtainBottom],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+                .ignoresSafeArea()
+            )
+            .overlay {
+                if viewModel.isAuthenticating {
+                    LoadingView(title: viewModel.loadingTitle).transition(.opacity)
+                }
+            }
+            .sheet(item: $activeLegalSheet) { document in
+                TermsSheet(
+                    markdown: document.markdown,
+                    title: document.title,
+                    subtitle: "Please review before continuing",
+                    iconSystemName: document.iconSystemName
+                )
+            }
+            .onChange(of: viewModel.acceptedGoogleTerms) { _, _ in
+                viewModel.clearGoogleLegalError()
+            }
+            .onChange(of: viewModel.acceptedGooglePrivacyPolicy) { _, _ in
+                viewModel.clearGoogleLegalError()
+            }
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        viewModel.cancelGoogleLegalAcceptance()
+                    }
+                    .disabled(viewModel.isAuthenticating)
+                }
+            }
+        }
+    }
+
+    private func legalConsentRow(
+        title: String,
+        linkTitle: String,
+        isAccepted: Binding<Bool>,
+        helperText: String?,
+        onLinkTap: @escaping () -> Void
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 12) {
+                Text(title)
+                    .font(.callout.weight(.semibold))
+                    .foregroundStyle(AuthTheme.textOnCurtainPrimary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                Toggle("", isOn: isAccepted)
+                    .labelsHidden()
+                    .tint(AuthTheme.linkOnCurtain)
+                    .disabled(viewModel.isAuthenticating)
+            }
+
+            Button(linkTitle, action: onLinkTap)
+                .buttonStyle(.plain)
+                .font(.footnote.weight(.semibold))
+                .foregroundStyle(AuthTheme.linkOnCurtain)
+                .underline()
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            if let helperText {
+                ValidationMessageView(message: helperText, palette: .curtain)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    private enum LegalSheet: String, Identifiable {
+        case terms
+        case privacyPolicy
+
+        var id: String { rawValue }
+
+        var title: String {
+            switch self {
+            case .terms: "Terms of Service"
+            case .privacyPolicy: "Privacy Policy"
+            }
+        }
+
+        var iconSystemName: String {
+            switch self {
+            case .terms: "doc.text"
+            case .privacyPolicy: "lock.doc"
+            }
+        }
+
+        var markdown: String {
+            switch self {
+            case .terms: TermsContent.termsMarkdown
+            case .privacyPolicy: TermsContent.privacyPolicyMarkdown
+            }
+        }
+    }
+}

--- a/CineMate/CineMate/Features/Account/Auth/Views/LoginView.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Views/LoginView.swift
@@ -14,14 +14,14 @@ struct LoginView: View {
     @EnvironmentObject private var toastCenter: ToastCenter
     @Environment(\.colorScheme) private var colorScheme
     private let onRegister: () -> Void
-
+    
     @State private var showResetSheet = false
     @FocusState private var emailFocused: Bool
     @FocusState private var passwordFocused: Bool
     private let authProviderButtonSize: CGFloat = 48
     private let authProviderCornerRadius: CGFloat = 12
     private let contentMaxWidth: CGFloat = 380
-
+    
     init(
         viewModel: LoginViewModel,
         onRegister: @escaping () -> Void = {}
@@ -29,50 +29,50 @@ struct LoginView: View {
         _viewModel = .init(wrappedValue: viewModel)
         self.onRegister = onRegister
     }
-
+    
     var body: some View {
         ZStack {
             LinearGradient(colors: [AuthTheme.curtainTop, AuthTheme.curtainBottom],
                            startPoint: .top, endPoint: .bottom)
             .ignoresSafeArea()
             AuthTheme.curtainContrastOverlay.ignoresSafeArea()
-
-            ScrollView(showsIndicators: false) {
-                VStack(spacing: 24) {
-                    loginHeader
-                        .padding(.top, 12)
-
-                    Spacer()
-
-                    VStack(alignment: .leading, spacing: 24) {
-                        AuthEmailField(
-                            text: $viewModel.email,
-                            isDisabled: viewModel.isAuthenticating,
-                            submitLabel: .next,
-                            onSubmit: { passwordFocused = true },
-                            isFocused: $emailFocused
-                        )
-                        if let hint = viewModel.emailHelperText {
-                            ValidationMessageView(message: hint, palette: .curtain)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                        }
-
-                        AuthPasswordField(
-                            text: $viewModel.password,
-                            isDisabled: viewModel.isAuthenticating,
-                            mode: .login,
-                            submitLabel: .go,
-                            onSubmit: {
-                                clearFieldFocus()
-                                Task { await viewModel.login() }
-                            },
-                            isFocused: $passwordFocused
-                        )
-                        if let hint = viewModel.passwordHelperText {
-                            ValidationMessageView(message: hint, palette: .curtain)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                        }
-
+            
+            VStack(spacing: 24) {
+                loginHeader
+                    .padding(.top, 28)
+                
+                Spacer()
+                
+                VStack(alignment: .leading, spacing: 24) {
+                    AuthEmailField(
+                        text: $viewModel.email,
+                        isDisabled: viewModel.isAuthenticating,
+                        submitLabel: .next,
+                        onSubmit: { passwordFocused = true },
+                        isFocused: $emailFocused
+                    )
+                    if let hint = viewModel.emailHelperText {
+                        ValidationMessageView(message: hint, palette: .curtain)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    
+                    AuthPasswordField(
+                        text: $viewModel.password,
+                        isDisabled: viewModel.isAuthenticating,
+                        mode: .login,
+                        submitLabel: .go,
+                        onSubmit: {
+                            clearFieldFocus()
+                            Task { await viewModel.login() }
+                        },
+                        isFocused: $passwordFocused
+                    )
+                    if let hint = viewModel.passwordHelperText {
+                        ValidationMessageView(message: hint, palette: .curtain)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    
+                    VStack(alignment: .leading, spacing: SharedUI.Spacing.medium) {
                         Button("Forgot password?") {
                             clearFieldFocus()
                             showResetSheet = true
@@ -82,7 +82,7 @@ struct LoginView: View {
                         .foregroundStyle(AuthTheme.linkOnCurtain)
                         .frame(maxWidth: .infinity, alignment: .trailing)
                         .disabled(viewModel.isAuthenticating)
-
+                        
                         Button {
                             clearFieldFocus()
                             Task { await viewModel.login() }
@@ -93,7 +93,7 @@ struct LoginView: View {
                         .controlSize(.large)
                         .frame(height: 48)
                         .disabled(viewModel.isAuthenticating)
-
+                        
                         if let message = viewModel.errorMessage {
                             AuthErrorBlock(
                                 message: message,
@@ -108,75 +108,74 @@ struct LoginView: View {
                                 }
                             }
                         }
-
-                        OrDivider(text: "or continue with")
-
-                        HStack(spacing: 16) {
-                            GoogleSignInButton(
-                                scheme: colorScheme == .dark ? .dark : .light,
-                                style: .icon,
-                                state: viewModel.isAuthenticating ? .disabled : .normal
-                            ) {
-                                clearFieldFocus()
-                                Task { await viewModel.signInWithGoogle() }
-                            }
-                            .frame(width: authProviderButtonSize, height: authProviderButtonSize)
-                            .clipShape(
-                                RoundedRectangle(
-                                    cornerRadius: authProviderCornerRadius,
-                                    style: .continuous
-                                )
-                            )
-                            .shadow(color: .black.opacity(0.06), radius: 6, y: 2)
-                            .accessibilityLabel("Sign in with Google")
-
-                            Button {
-                                clearFieldFocus()
-                                Task { await viewModel.continueAsGuest() }
-                            } label: {
-                                Image(systemName: "person.crop.circle.badge.questionmark")
-                                    .font(.system(size: 20, weight: .semibold))
-                                    .foregroundStyle(Color.tmdbNavy)
-                                    .frame(width: authProviderButtonSize, height: authProviderButtonSize)
-                                    .background(
-                                        RoundedRectangle(
-                                            cornerRadius: authProviderCornerRadius,
-                                            style: .continuous
-                                        )
-                                        .fill(Color.white)
-                                    )
-                                    .overlay(
-                                        RoundedRectangle(
-                                            cornerRadius: authProviderCornerRadius,
-                                            style: .continuous
-                                        )
-                                        .stroke(Color.white.opacity(0.78), lineWidth: 1)
-                                    )
-                                    .shadow(color: .black.opacity(0.06), radius: 6, y: 2)
-                            }
-                            .buttonStyle(.plain)
-                            .frame(width: authProviderButtonSize, height: authProviderButtonSize)
-                            .disabled(viewModel.isAuthenticating)
-                            .accessibilityLabel("Continue as guest")
-                        }
-                        .frame(maxWidth: .infinity)
-
-                        Text("Use Google for your account, or continue as guest without signing up.")
-                            .font(.caption)
-                            .foregroundStyle(AuthTheme.textOnCurtainSecondary)
-                            .multilineTextAlignment(.center)
-                            .frame(maxWidth: .infinity)
-                            .padding(.top, 2)
                     }
-                    .frame(maxWidth: contentMaxWidth)
-                    .padding(.horizontal, 20)
-
+                    
+                    OrDivider(text: "or continue with")
+                    
+                    HStack(spacing: 16) {
+                        GoogleSignInButton(
+                            scheme: colorScheme == .dark ? .dark : .light,
+                            style: .icon,
+                            state: viewModel.isAuthenticating ? .disabled : .normal
+                        ) {
+                            clearFieldFocus()
+                            Task { await viewModel.signInWithGoogle() }
+                        }
+                        .frame(width: authProviderButtonSize, height: authProviderButtonSize)
+                        .clipShape(
+                            RoundedRectangle(
+                                cornerRadius: authProviderCornerRadius,
+                                style: .continuous
+                            )
+                        )
+                        .shadow(color: .black.opacity(0.06), radius: 6, y: 2)
+                        .accessibilityLabel("Sign in with Google")
+                        
+                        Button {
+                            clearFieldFocus()
+                            Task { await viewModel.continueAsGuest() }
+                        } label: {
+                            Image(systemName: "person.crop.circle.badge.questionmark")
+                                .font(.system(size: 20, weight: .semibold))
+                                .foregroundStyle(Color.tmdbNavy)
+                                .frame(width: authProviderButtonSize, height: authProviderButtonSize)
+                                .background(
+                                    RoundedRectangle(
+                                        cornerRadius: authProviderCornerRadius,
+                                        style: .continuous
+                                    )
+                                    .fill(Color.white)
+                                )
+                                .overlay(
+                                    RoundedRectangle(
+                                        cornerRadius: authProviderCornerRadius,
+                                        style: .continuous
+                                    )
+                                    .stroke(Color.white.opacity(0.78), lineWidth: 1)
+                                )
+                                .shadow(color: .black.opacity(0.06), radius: 6, y: 2)
+                        }
+                        .buttonStyle(.plain)
+                        .frame(width: authProviderButtonSize, height: authProviderButtonSize)
+                        .disabled(viewModel.isAuthenticating)
+                        .accessibilityLabel("Continue as guest")
+                    }
+                    .frame(maxWidth: .infinity)
+                    
+                    Text("Use Google for your account, or continue as guest without signing up.")
+                        .font(.caption)
+                        .foregroundStyle(AuthTheme.textOnCurtainSecondary)
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: .infinity)
+                        .padding(.top, 2)
                 }
-                .frame(maxWidth: .infinity)
-                .padding(.top, 16)
-                .padding(.bottom, 20)
+                .frame(maxWidth: contentMaxWidth)
+                .padding(.horizontal, 20)
+                
+                Spacer()
             }
-            .scrollDismissesKeyboard(.interactively)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            .padding(.bottom, 20)
             .contentShape(Rectangle())
             .simultaneousGesture(
                 TapGesture().onEnded {
@@ -214,7 +213,7 @@ struct LoginView: View {
                 .padding(.bottom, 10)
         }
     }
-
+    
     @ViewBuilder
     private var loginHeader: some View {
 #if DEBUG
@@ -223,7 +222,7 @@ struct LoginView: View {
         AuthHeader()
 #endif
     }
-
+    
     private var registerPrompt: some View {
         HStack(spacing: 6) {
             Text("Don’t have an account?")
@@ -241,12 +240,12 @@ struct LoginView: View {
         .font(.footnote)
         .frame(maxWidth: .infinity)
     }
-
+    
     private func clearFieldFocus() {
         emailFocused = false
         passwordFocused = false
     }
-
+    
 #if DEBUG
     private func applyDebugCredentials() {
         guard let email = DebugLoginCredentials.email,

--- a/CineMate/CineMate/Features/Account/Auth/Views/LoginView.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Views/LoginView.swift
@@ -14,14 +14,14 @@ struct LoginView: View {
     @EnvironmentObject private var toastCenter: ToastCenter
     @Environment(\.colorScheme) private var colorScheme
     private let onRegister: () -> Void
-    
+
     @State private var showResetSheet = false
     @FocusState private var emailFocused: Bool
     @FocusState private var passwordFocused: Bool
     private let authProviderButtonSize: CGFloat = 48
     private let authProviderCornerRadius: CGFloat = 12
     private let contentMaxWidth: CGFloat = 380
-    
+
     init(
         viewModel: LoginViewModel,
         onRegister: @escaping () -> Void = {}
@@ -29,21 +29,21 @@ struct LoginView: View {
         _viewModel = .init(wrappedValue: viewModel)
         self.onRegister = onRegister
     }
-    
+
     var body: some View {
         ZStack {
             LinearGradient(colors: [AuthTheme.curtainTop, AuthTheme.curtainBottom],
                            startPoint: .top, endPoint: .bottom)
             .ignoresSafeArea()
             AuthTheme.curtainContrastOverlay.ignoresSafeArea()
-            
+
             ScrollView(showsIndicators: false) {
                 VStack(spacing: 24) {
                     loginHeader
                         .padding(.top, 12)
-                    
+
                     Spacer()
-                    
+
                     VStack(alignment: .leading, spacing: 24) {
                         AuthEmailField(
                             text: $viewModel.email,
@@ -56,35 +56,44 @@ struct LoginView: View {
                             ValidationMessageView(message: hint, palette: .curtain)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                         }
-                        
+
                         AuthPasswordField(
                             text: $viewModel.password,
                             isDisabled: viewModel.isAuthenticating,
                             mode: .login,
                             submitLabel: .go,
-                            onSubmit: { Task { await viewModel.login() } },
+                            onSubmit: {
+                                clearFieldFocus()
+                                Task { await viewModel.login() }
+                            },
                             isFocused: $passwordFocused
                         )
                         if let hint = viewModel.passwordHelperText {
                             ValidationMessageView(message: hint, palette: .curtain)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                         }
-                        
-                        Button("Forgot password?") { showResetSheet = true }
-                            .buttonStyle(.plain)
-                            .font(.footnote.weight(.semibold))
-                            .foregroundStyle(AuthTheme.linkOnCurtain)
-                            .frame(maxWidth: .infinity, alignment: .trailing)
-                            .disabled(viewModel.isAuthenticating)
-                        
-                        Button { Task { await viewModel.login() } } label: {
+
+                        Button("Forgot password?") {
+                            clearFieldFocus()
+                            showResetSheet = true
+                        }
+                        .buttonStyle(.plain)
+                        .font(.footnote.weight(.semibold))
+                        .foregroundStyle(AuthTheme.linkOnCurtain)
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                        .disabled(viewModel.isAuthenticating)
+
+                        Button {
+                            clearFieldFocus()
+                            Task { await viewModel.login() }
+                        } label: {
                             Text("Sign in").fontWeight(.semibold).frame(maxWidth: .infinity)
                         }
                         .buttonStyle(.pillWhite)
                         .controlSize(.large)
                         .frame(height: 48)
                         .disabled(viewModel.isAuthenticating)
-                        
+
                         if let message = viewModel.errorMessage {
                             AuthErrorBlock(
                                 message: message,
@@ -99,26 +108,30 @@ struct LoginView: View {
                                 }
                             }
                         }
-                        
+
                         OrDivider(text: "or continue with")
-                        
+
                         HStack(spacing: 16) {
                             GoogleSignInButton(
                                 scheme: colorScheme == .dark ? .dark : .light,
                                 style: .icon,
                                 state: viewModel.isAuthenticating ? .disabled : .normal
-                            ) { Task { await viewModel.signInWithGoogle() } }
-                                .frame(width: authProviderButtonSize, height: authProviderButtonSize)
-                                .clipShape(
-                                    RoundedRectangle(
-                                        cornerRadius: authProviderCornerRadius,
-                                        style: .continuous
-                                    )
+                            ) {
+                                clearFieldFocus()
+                                Task { await viewModel.signInWithGoogle() }
+                            }
+                            .frame(width: authProviderButtonSize, height: authProviderButtonSize)
+                            .clipShape(
+                                RoundedRectangle(
+                                    cornerRadius: authProviderCornerRadius,
+                                    style: .continuous
                                 )
-                                .shadow(color: .black.opacity(0.06), radius: 6, y: 2)
-                                .accessibilityLabel("Sign in with Google")
-                            
+                            )
+                            .shadow(color: .black.opacity(0.06), radius: 6, y: 2)
+                            .accessibilityLabel("Sign in with Google")
+
                             Button {
+                                clearFieldFocus()
                                 Task { await viewModel.continueAsGuest() }
                             } label: {
                                 Image(systemName: "person.crop.circle.badge.questionmark")
@@ -147,7 +160,7 @@ struct LoginView: View {
                             .accessibilityLabel("Continue as guest")
                         }
                         .frame(maxWidth: .infinity)
-                        
+
                         Text("Use Google for your account, or continue as guest without signing up.")
                             .font(.caption)
                             .foregroundStyle(AuthTheme.textOnCurtainSecondary)
@@ -157,16 +170,22 @@ struct LoginView: View {
                     }
                     .frame(maxWidth: contentMaxWidth)
                     .padding(.horizontal, 20)
-                    
+
                 }
                 .frame(maxWidth: .infinity)
                 .padding(.top, 16)
                 .padding(.bottom, 20)
             }
+            .scrollDismissesKeyboard(.interactively)
+            .contentShape(Rectangle())
+            .simultaneousGesture(
+                TapGesture().onEnded {
+                    clearFieldFocus()
+                }
+            )
         }
         .onAppear {
-            emailFocused = false
-            passwordFocused = false
+            clearFieldFocus()
         }
         .overlay {
             if viewModel.isAuthenticating {
@@ -195,7 +214,7 @@ struct LoginView: View {
                 .padding(.bottom, 10)
         }
     }
-    
+
     @ViewBuilder
     private var loginHeader: some View {
 #if DEBUG
@@ -204,22 +223,30 @@ struct LoginView: View {
         AuthHeader()
 #endif
     }
-    
+
     private var registerPrompt: some View {
         HStack(spacing: 6) {
             Text("Don’t have an account?")
                 .foregroundStyle(AuthTheme.textOnCurtainSecondary)
-            Button("Register") { onRegister() }
-                .buttonStyle(.plain)
-                .foregroundStyle(AuthTheme.linkOnCurtain)
-                .underline()
-                .accessibilityAddTraits(.isLink)
-                .disabled(viewModel.isAuthenticating)
+            Button("Register") {
+                clearFieldFocus()
+                onRegister()
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(AuthTheme.linkOnCurtain)
+            .underline()
+            .accessibilityAddTraits(.isLink)
+            .disabled(viewModel.isAuthenticating)
         }
         .font(.footnote)
         .frame(maxWidth: .infinity)
     }
-    
+
+    private func clearFieldFocus() {
+        emailFocused = false
+        passwordFocused = false
+    }
+
 #if DEBUG
     private func applyDebugCredentials() {
         guard let email = DebugLoginCredentials.email,
@@ -231,8 +258,7 @@ struct LoginView: View {
         viewModel.password = password
         viewModel.hasTriedSubmit = false
         viewModel.clearError()
-        emailFocused = false
-        passwordFocused = false
+        clearFieldFocus()
         toastCenter.show("Debug credentials applied")
     }
 #endif
@@ -244,175 +270,3 @@ struct LoginView: View {
 #Preview("Filled") { LoginView.previewFilled }
 #Preview("Error") { LoginView.previewError }
 #Preview("Authenticating") { LoginView.previewIsAuthenticating }
-
-private struct GoogleLegalAcceptanceSheet: View {
-    @ObservedObject var viewModel: LoginViewModel
-    @State private var activeLegalSheet: LegalSheet?
-
-    var body: some View {
-        NavigationStack {
-            VStack(alignment: .leading, spacing: 18) {
-                VStack(alignment: .leading, spacing: 8) {
-                    Image(systemName: "checkmark.shield")
-                        .font(.system(size: 30, weight: .semibold))
-                        .foregroundStyle(AuthTheme.popcorn)
-                    Text("Review before continuing")
-                        .font(.title3.weight(.bold))
-                        .foregroundStyle(AuthTheme.textOnCurtainPrimary)
-                    Text("Accept the same terms and privacy policy used for email accounts to finish Google sign-in.")
-                        .font(.callout)
-                        .foregroundStyle(AuthTheme.textOnCurtainSecondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-
-                legalConsentRow(
-                    title: "I accept the Terms of Service",
-                    linkTitle: "View terms",
-                    isAccepted: $viewModel.acceptedGoogleTerms,
-                    helperText: viewModel.googleTermsHelperText,
-                    onLinkTap: { activeLegalSheet = .terms }
-                )
-
-                legalConsentRow(
-                    title: "I accept the Privacy Policy",
-                    linkTitle: "View privacy policy",
-                    isAccepted: $viewModel.acceptedGooglePrivacyPolicy,
-                    helperText: viewModel.googlePrivacyPolicyHelperText,
-                    onLinkTap: { activeLegalSheet = .privacyPolicy }
-                )
-
-                if let message = viewModel.errorMessage {
-                    AuthErrorBlock(message: message)
-                }
-
-                Button {
-                    Task { await viewModel.acceptGoogleLegalTerms() }
-                } label: {
-                    Text("Continue")
-                        .fontWeight(.semibold)
-                        .frame(maxWidth: .infinity)
-                }
-                .buttonStyle(.pillWhite)
-                .controlSize(.large)
-                .frame(height: 48)
-                .disabled(viewModel.isAuthenticating)
-
-                Spacer(minLength: 0)
-            }
-            .padding(20)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-            .background(
-                LinearGradient(
-                    colors: [AuthTheme.curtainTop, AuthTheme.curtainBottom],
-                    startPoint: .top,
-                    endPoint: .bottom
-                )
-                .ignoresSafeArea()
-            )
-            .overlay {
-                if viewModel.isAuthenticating {
-                    LoadingView(title: viewModel.loadingTitle).transition(.opacity)
-                }
-            }
-            .sheet(item: $activeLegalSheet) { document in
-                TermsSheet(
-                    markdown: document.markdown,
-                    title: document.title,
-                    subtitle: "Please review before continuing",
-                    iconSystemName: document.iconSystemName
-                )
-            }
-            .onChange(of: viewModel.acceptedGoogleTerms) { _, _ in
-                viewModel.clearGoogleLegalError()
-            }
-            .onChange(of: viewModel.acceptedGooglePrivacyPolicy) { _, _ in
-                viewModel.clearGoogleLegalError()
-            }
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") {
-                        viewModel.cancelGoogleLegalAcceptance()
-                    }
-                    .disabled(viewModel.isAuthenticating)
-                }
-            }
-        }
-    }
-
-    private func legalConsentRow(
-        title: String,
-        linkTitle: String,
-        isAccepted: Binding<Bool>,
-        helperText: String?,
-        onLinkTap: @escaping () -> Void
-    ) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack(spacing: 12) {
-                Text(title)
-                    .font(.callout.weight(.semibold))
-                    .foregroundStyle(AuthTheme.textOnCurtainPrimary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                Toggle("", isOn: isAccepted)
-                    .labelsHidden()
-                    .tint(AuthTheme.linkOnCurtain)
-                    .disabled(viewModel.isAuthenticating)
-            }
-
-            Button(linkTitle, action: onLinkTap)
-                .buttonStyle(.plain)
-                .font(.footnote.weight(.semibold))
-                .foregroundStyle(AuthTheme.linkOnCurtain)
-                .underline()
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-            if let helperText {
-                ValidationMessageView(message: helperText, palette: .curtain)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            }
-        }
-    }
-
-    private enum LegalSheet: String, Identifiable {
-        case terms
-        case privacyPolicy
-
-        var id: String { rawValue }
-
-        var title: String {
-            switch self {
-            case .terms: "Terms of Service"
-            case .privacyPolicy: "Privacy Policy"
-            }
-        }
-
-        var iconSystemName: String {
-            switch self {
-            case .terms: "doc.text"
-            case .privacyPolicy: "lock.doc"
-            }
-        }
-
-        var markdown: String {
-            switch self {
-            case .terms: TermsContent.termsMarkdown
-            case .privacyPolicy: TermsContent.privacyPolicyMarkdown
-            }
-        }
-    }
-}
-
-#if DEBUG
-private enum DebugLoginCredentials {
-    private static let environment = ProcessInfo.processInfo.environment
-    
-    static var email: String? { sanitize(environment["DEBUG_LOGIN_EMAIL"]) }
-    static var password: String? { sanitize(environment["DEBUG_LOGIN_PASSWORD"]) }
-    
-    private static func sanitize(_ value: String?) -> String? {
-        guard let value else { return nil }
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : trimmed
-    }
-}
-#endif

--- a/CineMate/CineMate/Features/UI/Components/Shared/LoadingView.swift
+++ b/CineMate/CineMate/Features/UI/Components/Shared/LoadingView.swift
@@ -11,7 +11,7 @@ struct LoadingView: View {
     let title: String
     
     var body: some View {
-        OverlayContainer(backdrop: .material) {
+        OverlayContainer(backdrop: .dimmed(0.18)) {
             OverlayCard {
                 ProgressView()
                     .progressViewStyle(.circular)


### PR DESCRIPTION
## Summary

- split Google legal acceptance into its own sheet
- move debug login credentials into a debug file
- update the Xcode project for the new auth files
- simplify the LoginView layout
- improve focus handling and keyboard dismissal
- align auth errors and validation text to the left
- add a warning color for auth messages on the curtain background
- defer navigator reset during auth gate changes
- use a dimmed backdrop for loading overlays
- keep app bootstrap and auth gate formatting cleaner

## Changed files

- CineMateApp.swift
- AppNavigator.swift
- AuthTheme.swift
- AuthErrorBlock.swift
- ValidationMessageView.swift
- LoginView.swift
- LoadingView.swift
- GoogleLegalAcceptanceSheet.swift
- DebugLoginCredentials.swift
- project.pbxproj