### PR TITLE
feat(account): polish account tab

### DIFF
--- a/CineMate/CineMate.xcodeproj/project.pbxproj
+++ b/CineMate/CineMate.xcodeproj/project.pbxproj
@@ -113,6 +113,8 @@
 		03618C3B2E6F100500D75D10 /* AccountSessionSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03618C3A2E6F100500D75D10 /* AccountSessionSectionView.swift */; };
 		03618C3D2E6F180100D75D10 /* AccountView+Feedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03618C3C2E6F180100D75D10 /* AccountView+Feedback.swift */; };
 		03623F232E2D6E6E00066528 /* PreviewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03623F222E2D6E6E00066528 /* PreviewHelpers.swift */; };
+		03618C412E6F3A0100D75D10 /* AccountErrorMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03618C402E6F3A0100D75D10 /* AccountErrorMessageView.swift */; };
+		03618C432E6F3A0200D75D10 /* AccountInlineFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03618C422E6F3A0200D75D10 /* AccountInlineFeedback.swift */; };
 		03652CE52DFC56830031DCAD /* MovieDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03652CE42DFC56830031DCAD /* MovieDetail.swift */; };
 		036623782E2065CD008FDE2E /* DiscoverPreviewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036623772E2065CD008FDE2E /* DiscoverPreviewData.swift */; };
 		0366237A2E2065E2008FDE2E /* DiscoverSectionView+Previews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036623792E2065E2008FDE2E /* DiscoverSectionView+Previews.swift */; };
@@ -390,6 +392,8 @@
 		03618C382E6F100400D75D10 /* AccountLegalSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountLegalSectionView.swift; sourceTree = "<group>"; };
 		03618C3A2E6F100500D75D10 /* AccountSessionSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSessionSectionView.swift; sourceTree = "<group>"; };
 		03618C3C2E6F180100D75D10 /* AccountView+Feedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AccountView+Feedback.swift"; sourceTree = "<group>"; };
+		03618C402E6F3A0100D75D10 /* AccountErrorMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountErrorMessageView.swift; sourceTree = "<group>"; };
+		03618C422E6F3A0200D75D10 /* AccountInlineFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountInlineFeedback.swift; sourceTree = "<group>"; };
 		03623F222E2D6E6E00066528 /* PreviewHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewHelpers.swift; sourceTree = "<group>"; };
 		03652CE42DFC56830031DCAD /* MovieDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetail.swift; sourceTree = "<group>"; };
 		036623772E2065CD008FDE2E /* DiscoverPreviewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverPreviewData.swift; sourceTree = "<group>"; };
@@ -1177,6 +1181,8 @@
 			children = (
 				03618C322E6F100100D75D10 /* AccountSummarySectionView.swift */,
 				03618C3E2E6F2D0100D75D10 /* AccountSummaryContent.swift */,
+				03618C402E6F3A0100D75D10 /* AccountErrorMessageView.swift */,
+				03618C422E6F3A0200D75D10 /* AccountInlineFeedback.swift */,
 				03618C342E6F100200D75D10 /* GuestAccountSectionView.swift */,
 				03618C362E6F100300D75D10 /* AccountSecuritySectionView.swift */,
 				03618C382E6F100400D75D10 /* AccountLegalSectionView.swift */,
@@ -1927,6 +1933,8 @@
 				035CB2C02E51CA6500892271 /* AuthViewModel.swift in Sources */,
 				03618C332E6F100100D75D10 /* AccountSummarySectionView.swift in Sources */,
 				03618C3F2E6F2D0100D75D10 /* AccountSummaryContent.swift in Sources */,
+				03618C412E6F3A0100D75D10 /* AccountErrorMessageView.swift in Sources */,
+				03618C432E6F3A0200D75D10 /* AccountInlineFeedback.swift in Sources */,
 				03618C352E6F100200D75D10 /* GuestAccountSectionView.swift in Sources */,
 				03618C372E6F100300D75D10 /* AccountSecuritySectionView.swift in Sources */,
 				03618C392E6F100400D75D10 /* AccountLegalSectionView.swift in Sources */,

--- a/CineMate/CineMate.xcodeproj/project.pbxproj
+++ b/CineMate/CineMate.xcodeproj/project.pbxproj
@@ -106,10 +106,12 @@
 		03618C2F2E68DB1100D75D10 /* FirebaseAuthService+Deletion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03618C2E2E68DB1100D75D10 /* FirebaseAuthService+Deletion.swift */; };
 		03618C312E68E79D00D75D10 /* AccountDangerZoneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03618C302E68E79D00D75D10 /* AccountDangerZoneView.swift */; };
 		03618C332E6F100100D75D10 /* AccountSummarySectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03618C322E6F100100D75D10 /* AccountSummarySectionView.swift */; };
+		03618C3F2E6F2D0100D75D10 /* AccountSummaryContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03618C3E2E6F2D0100D75D10 /* AccountSummaryContent.swift */; };
 		03618C352E6F100200D75D10 /* GuestAccountSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03618C342E6F100200D75D10 /* GuestAccountSectionView.swift */; };
 		03618C372E6F100300D75D10 /* AccountSecuritySectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03618C362E6F100300D75D10 /* AccountSecuritySectionView.swift */; };
 		03618C392E6F100400D75D10 /* AccountLegalSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03618C382E6F100400D75D10 /* AccountLegalSectionView.swift */; };
 		03618C3B2E6F100500D75D10 /* AccountSessionSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03618C3A2E6F100500D75D10 /* AccountSessionSectionView.swift */; };
+		03618C3D2E6F180100D75D10 /* AccountView+Feedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03618C3C2E6F180100D75D10 /* AccountView+Feedback.swift */; };
 		03623F232E2D6E6E00066528 /* PreviewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03623F222E2D6E6E00066528 /* PreviewHelpers.swift */; };
 		03652CE52DFC56830031DCAD /* MovieDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03652CE42DFC56830031DCAD /* MovieDetail.swift */; };
 		036623782E2065CD008FDE2E /* DiscoverPreviewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036623772E2065CD008FDE2E /* DiscoverPreviewData.swift */; };
@@ -382,10 +384,12 @@
 		03618C2E2E68DB1100D75D10 /* FirebaseAuthService+Deletion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FirebaseAuthService+Deletion.swift"; sourceTree = "<group>"; };
 		03618C302E68E79D00D75D10 /* AccountDangerZoneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountDangerZoneView.swift; sourceTree = "<group>"; };
 		03618C322E6F100100D75D10 /* AccountSummarySectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSummarySectionView.swift; sourceTree = "<group>"; };
+		03618C3E2E6F2D0100D75D10 /* AccountSummaryContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSummaryContent.swift; sourceTree = "<group>"; };
 		03618C342E6F100200D75D10 /* GuestAccountSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuestAccountSectionView.swift; sourceTree = "<group>"; };
 		03618C362E6F100300D75D10 /* AccountSecuritySectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSecuritySectionView.swift; sourceTree = "<group>"; };
 		03618C382E6F100400D75D10 /* AccountLegalSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountLegalSectionView.swift; sourceTree = "<group>"; };
 		03618C3A2E6F100500D75D10 /* AccountSessionSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSessionSectionView.swift; sourceTree = "<group>"; };
+		03618C3C2E6F180100D75D10 /* AccountView+Feedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AccountView+Feedback.swift"; sourceTree = "<group>"; };
 		03623F222E2D6E6E00066528 /* PreviewHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewHelpers.swift; sourceTree = "<group>"; };
 		03652CE42DFC56830031DCAD /* MovieDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetail.swift; sourceTree = "<group>"; };
 		036623772E2065CD008FDE2E /* DiscoverPreviewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverPreviewData.swift; sourceTree = "<group>"; };
@@ -924,6 +928,7 @@
 				A1B2D0022F7600010010ABCD /* GoogleLegalAcceptanceSheet.swift */,
 				0397B36F2E5517E400065408 /* CreateAccountView.swift */,
 				03CB4AAD2E1876500080EE84 /* AccountView.swift */,
+				03618C3C2E6F180100D75D10 /* AccountView+Feedback.swift */,
 				A1B2C3D42F70000100ABCDEF /* ChangeEmailSheet.swift */,
 				036E06AB2E5B97B6006BBA92 /* ResetPasswordSheet.swift */,
 			);
@@ -1171,6 +1176,7 @@
 			isa = PBXGroup;
 			children = (
 				03618C322E6F100100D75D10 /* AccountSummarySectionView.swift */,
+				03618C3E2E6F2D0100D75D10 /* AccountSummaryContent.swift */,
 				03618C342E6F100200D75D10 /* GuestAccountSectionView.swift */,
 				03618C362E6F100300D75D10 /* AccountSecuritySectionView.swift */,
 				03618C382E6F100400D75D10 /* AccountLegalSectionView.swift */,
@@ -1863,6 +1869,7 @@
 				030289CA2E52768B00F8AF00 /* FirebaseAuthService.swift in Sources */,
 				033277EF2E15BF5700E5A226 /* WatchProviderListView+Previews.swift in Sources */,
 				03CB4AAE2E1876500080EE84 /* AccountView.swift in Sources */,
+				03618C3D2E6F180100D75D10 /* AccountView+Feedback.swift in Sources */,
 				A1B2C3D52F70000100ABCDEF /* ChangeEmailSheet.swift in Sources */,
 				0305997A2E1F05A500626215 /* DiscoverView+Previews.swift in Sources */,
 				03E090DB2E25A2AE00ECBF5F /* GenreChipView+Previews.swift in Sources */,
@@ -1919,6 +1926,7 @@
 				03920A692E24F15B00804B06 /* SeeAllMoviesViewModel.swift in Sources */,
 				035CB2C02E51CA6500892271 /* AuthViewModel.swift in Sources */,
 				03618C332E6F100100D75D10 /* AccountSummarySectionView.swift in Sources */,
+				03618C3F2E6F2D0100D75D10 /* AccountSummaryContent.swift in Sources */,
 				03618C352E6F100200D75D10 /* GuestAccountSectionView.swift in Sources */,
 				03618C372E6F100300D75D10 /* AccountSecuritySectionView.swift in Sources */,
 				03618C392E6F100400D75D10 /* AccountLegalSectionView.swift in Sources */,

--- a/CineMate/CineMate.xcodeproj/project.pbxproj
+++ b/CineMate/CineMate.xcodeproj/project.pbxproj
@@ -105,6 +105,11 @@
 		035CB2C02E51CA6500892271 /* AuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035CB2BF2E51CA6500892271 /* AuthViewModel.swift */; };
 		03618C2F2E68DB1100D75D10 /* FirebaseAuthService+Deletion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03618C2E2E68DB1100D75D10 /* FirebaseAuthService+Deletion.swift */; };
 		03618C312E68E79D00D75D10 /* AccountDangerZoneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03618C302E68E79D00D75D10 /* AccountDangerZoneView.swift */; };
+		03618C332E6F100100D75D10 /* AccountSummarySectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03618C322E6F100100D75D10 /* AccountSummarySectionView.swift */; };
+		03618C352E6F100200D75D10 /* GuestAccountSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03618C342E6F100200D75D10 /* GuestAccountSectionView.swift */; };
+		03618C372E6F100300D75D10 /* AccountSecuritySectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03618C362E6F100300D75D10 /* AccountSecuritySectionView.swift */; };
+		03618C392E6F100400D75D10 /* AccountLegalSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03618C382E6F100400D75D10 /* AccountLegalSectionView.swift */; };
+		03618C3B2E6F100500D75D10 /* AccountSessionSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03618C3A2E6F100500D75D10 /* AccountSessionSectionView.swift */; };
 		03623F232E2D6E6E00066528 /* PreviewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03623F222E2D6E6E00066528 /* PreviewHelpers.swift */; };
 		03652CE52DFC56830031DCAD /* MovieDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03652CE42DFC56830031DCAD /* MovieDetail.swift */; };
 		036623782E2065CD008FDE2E /* DiscoverPreviewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036623772E2065CD008FDE2E /* DiscoverPreviewData.swift */; };
@@ -376,6 +381,11 @@
 		035CB2BF2E51CA6500892271 /* AuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewModel.swift; sourceTree = "<group>"; };
 		03618C2E2E68DB1100D75D10 /* FirebaseAuthService+Deletion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FirebaseAuthService+Deletion.swift"; sourceTree = "<group>"; };
 		03618C302E68E79D00D75D10 /* AccountDangerZoneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountDangerZoneView.swift; sourceTree = "<group>"; };
+		03618C322E6F100100D75D10 /* AccountSummarySectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSummarySectionView.swift; sourceTree = "<group>"; };
+		03618C342E6F100200D75D10 /* GuestAccountSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuestAccountSectionView.swift; sourceTree = "<group>"; };
+		03618C362E6F100300D75D10 /* AccountSecuritySectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSecuritySectionView.swift; sourceTree = "<group>"; };
+		03618C382E6F100400D75D10 /* AccountLegalSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountLegalSectionView.swift; sourceTree = "<group>"; };
+		03618C3A2E6F100500D75D10 /* AccountSessionSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSessionSectionView.swift; sourceTree = "<group>"; };
 		03623F222E2D6E6E00066528 /* PreviewHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewHelpers.swift; sourceTree = "<group>"; };
 		03652CE42DFC56830031DCAD /* MovieDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetail.swift; sourceTree = "<group>"; };
 		036623772E2065CD008FDE2E /* DiscoverPreviewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverPreviewData.swift; sourceTree = "<group>"; };
@@ -1160,6 +1170,11 @@
 		0390F7DC2E5DE36F00E89B82 /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				03618C322E6F100100D75D10 /* AccountSummarySectionView.swift */,
+				03618C342E6F100200D75D10 /* GuestAccountSectionView.swift */,
+				03618C362E6F100300D75D10 /* AccountSecuritySectionView.swift */,
+				03618C382E6F100400D75D10 /* AccountLegalSectionView.swift */,
+				03618C3A2E6F100500D75D10 /* AccountSessionSectionView.swift */,
 				0390F7DE2E5DE78200E89B82 /* AuthEmailField.swift */,
 				0390F7E02E5DE79300E89B82 /* AuthPasswordField.swift */,
 				0390F7E22E5DE7AA00E89B82 /* AuthErrorBlock.swift */,
@@ -1903,6 +1918,11 @@
 				03CD89D32E225C39004862AE /* DiscoverContentView.swift in Sources */,
 				03920A692E24F15B00804B06 /* SeeAllMoviesViewModel.swift in Sources */,
 				035CB2C02E51CA6500892271 /* AuthViewModel.swift in Sources */,
+				03618C332E6F100100D75D10 /* AccountSummarySectionView.swift in Sources */,
+				03618C352E6F100200D75D10 /* GuestAccountSectionView.swift in Sources */,
+				03618C372E6F100300D75D10 /* AccountSecuritySectionView.swift in Sources */,
+				03618C392E6F100400D75D10 /* AccountLegalSectionView.swift in Sources */,
+				03618C3B2E6F100500D75D10 /* AccountSessionSectionView.swift in Sources */,
 				0390F7DF2E5DE78200E89B82 /* AuthEmailField.swift in Sources */,
 				03618C312E68E79D00D75D10 /* AccountDangerZoneView.swift in Sources */,
 				03DCB0642E5604890071C3B2 /* PreviewFactory+CreateAccount.swift in Sources */,

--- a/CineMate/CineMate.xcodeproj/project.pbxproj
+++ b/CineMate/CineMate.xcodeproj/project.pbxproj
@@ -115,6 +115,8 @@
 		03623F232E2D6E6E00066528 /* PreviewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03623F222E2D6E6E00066528 /* PreviewHelpers.swift */; };
 		03618C412E6F3A0100D75D10 /* AccountErrorMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03618C402E6F3A0100D75D10 /* AccountErrorMessageView.swift */; };
 		03618C432E6F3A0200D75D10 /* AccountInlineFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03618C422E6F3A0200D75D10 /* AccountInlineFeedback.swift */; };
+		03618C452E6F4A0100D75D10 /* AccountLegalStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03618C442E6F4A0100D75D10 /* AccountLegalStatus.swift */; };
+		03618C472E6F4A0200D75D10 /* AccountSecurityStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03618C462E6F4A0200D75D10 /* AccountSecurityStatus.swift */; };
 		03652CE52DFC56830031DCAD /* MovieDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03652CE42DFC56830031DCAD /* MovieDetail.swift */; };
 		036623782E2065CD008FDE2E /* DiscoverPreviewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036623772E2065CD008FDE2E /* DiscoverPreviewData.swift */; };
 		0366237A2E2065E2008FDE2E /* DiscoverSectionView+Previews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036623792E2065E2008FDE2E /* DiscoverSectionView+Previews.swift */; };
@@ -394,6 +396,8 @@
 		03618C3C2E6F180100D75D10 /* AccountView+Feedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AccountView+Feedback.swift"; sourceTree = "<group>"; };
 		03618C402E6F3A0100D75D10 /* AccountErrorMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountErrorMessageView.swift; sourceTree = "<group>"; };
 		03618C422E6F3A0200D75D10 /* AccountInlineFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountInlineFeedback.swift; sourceTree = "<group>"; };
+		03618C442E6F4A0100D75D10 /* AccountLegalStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountLegalStatus.swift; sourceTree = "<group>"; };
+		03618C462E6F4A0200D75D10 /* AccountSecurityStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSecurityStatus.swift; sourceTree = "<group>"; };
 		03623F222E2D6E6E00066528 /* PreviewHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewHelpers.swift; sourceTree = "<group>"; };
 		03652CE42DFC56830031DCAD /* MovieDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetail.swift; sourceTree = "<group>"; };
 		036623772E2065CD008FDE2E /* DiscoverPreviewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverPreviewData.swift; sourceTree = "<group>"; };
@@ -1183,6 +1187,8 @@
 				03618C3E2E6F2D0100D75D10 /* AccountSummaryContent.swift */,
 				03618C402E6F3A0100D75D10 /* AccountErrorMessageView.swift */,
 				03618C422E6F3A0200D75D10 /* AccountInlineFeedback.swift */,
+				03618C442E6F4A0100D75D10 /* AccountLegalStatus.swift */,
+				03618C462E6F4A0200D75D10 /* AccountSecurityStatus.swift */,
 				03618C342E6F100200D75D10 /* GuestAccountSectionView.swift */,
 				03618C362E6F100300D75D10 /* AccountSecuritySectionView.swift */,
 				03618C382E6F100400D75D10 /* AccountLegalSectionView.swift */,
@@ -1935,6 +1941,8 @@
 				03618C3F2E6F2D0100D75D10 /* AccountSummaryContent.swift in Sources */,
 				03618C412E6F3A0100D75D10 /* AccountErrorMessageView.swift in Sources */,
 				03618C432E6F3A0200D75D10 /* AccountInlineFeedback.swift in Sources */,
+				03618C452E6F4A0100D75D10 /* AccountLegalStatus.swift in Sources */,
+				03618C472E6F4A0200D75D10 /* AccountSecurityStatus.swift in Sources */,
 				03618C352E6F100200D75D10 /* GuestAccountSectionView.swift in Sources */,
 				03618C372E6F100300D75D10 /* AccountSecuritySectionView.swift in Sources */,
 				03618C392E6F100400D75D10 /* AccountLegalSectionView.swift in Sources */,

--- a/CineMate/CineMate/Features/Account/Auth/Components/AccountDangerZoneView.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Components/AccountDangerZoneView.swift
@@ -7,45 +7,76 @@
 
 import SwiftUI
 
+/// Presents irreversible account deletion with clear risk copy and local confirmation.
 struct AccountDangerZoneView: View {
     @ObservedObject var authViewModel: AuthViewModel
     let onReauthenticationRequired: () -> Void
     let onDeleteSuccess: () -> Void
     let onDeleteFailure: (String) -> Void
-
+    
     @State private var isShowingDeleteAlert = false
-
+    
     var body: some View {
         Section {
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Danger Zone")
-                    .font(.headline)
-
-                Text("Delete your account and remove all data. This action cannot be undone")
-                    .font(.subheadline)
-                    .foregroundStyle(Color.appTextSecondary)
-
+            VStack(alignment: .leading, spacing: SharedUI.Spacing.large) {
+                HStack(alignment: .top, spacing: SharedUI.Spacing.medium) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.headline)
+                        .foregroundStyle(Color.appDestructive)
+                        .frame(width: SharedUI.Size.iconButton, height: SharedUI.Size.iconButton)
+                        .background(
+                            Circle()
+                                .fill(Color.appDestructive.opacity(0.12))
+                        )
+                    
+                    VStack(alignment: .leading, spacing: SharedUI.Spacing.xSmall) {
+                        Text("Danger Zone")
+                            .font(.headline)
+                            .foregroundStyle(Color.appTextPrimary)
+                        
+                        Text("Delete your account, saved favorites, favorite people, and account data.")
+                            .font(.subheadline)
+                            .foregroundStyle(Color.appTextSecondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                
+                Divider()
+                
+                VStack(alignment: .leading, spacing: SharedUI.Spacing.xSmall) {
+                    Text("This cannot be undone.")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(Color.appTextPrimary)
+                    
+                    Text("For security, CineMate may ask you to sign in again before deleting the account.")
+                        .font(.footnote)
+                        .foregroundStyle(Color.appTextSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                
                 Button(role: .destructive) {
                     isShowingDeleteAlert = true
                 } label: {
-                    Text("Delete Account")
+                    Text("Delete account")
                         .frame(maxWidth: .infinity)
                 }
                 .buttonStyle(.bordered)
+                .tint(Color.appDestructive)
                 .disabled(authViewModel.isAuthenticating)
-                .alert("Delete account?", isPresented: $isShowingDeleteAlert) {
-                    Button("Delete", role: .destructive) {
+                .alert("Permanently delete account?", isPresented: $isShowingDeleteAlert) {
+                    Button("Delete account", role: .destructive) {
                         Task { await deleteAccount() }
                     }
                     Button("Cancel", role: .cancel) {}
                 } message: {
-                    Text("This will permanently remove your account and data")
+                    Text("This removes your account, saved favorites, favorite people, and account data. This cannot be undone.")
                 }
             }
-            .padding(.vertical, 4)
+            .padding(.vertical, SharedUI.Spacing.small)
+            .listRowBackground(Color.appDestructive.opacity(0.055))
         }
     }
-
+    
     @MainActor
     private func deleteAccount() async {
         switch await authViewModel.deleteCurrentAccount() {

--- a/CineMate/CineMate/Features/Account/Auth/Components/AccountErrorMessageView.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Components/AccountErrorMessageView.swift
@@ -1,0 +1,32 @@
+//
+//  AccountErrorMessageView.swift
+//  CineMate
+//
+//  Created by OpenAI Codex on 2026-06-03.
+//
+
+import SwiftUI
+
+/// Inline fallback error shown on the account screen when no section-specific feedback is active.
+struct AccountErrorMessageView: View {
+    let message: String
+    let onDismiss: () -> Void
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: SharedUI.Spacing.small) {
+            Label("Authentication Error", systemImage: "exclamationmark.circle.fill")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(Color.appDestructive)
+            
+            Text(message)
+                .font(.subheadline)
+                .foregroundStyle(Color.appTextSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+            
+            Button("Dismiss", action: onDismiss)
+                .buttonStyle(.bordered)
+                .tint(.appPrimaryAction)
+        }
+        .padding(.vertical, 2)
+    }
+}

--- a/CineMate/CineMate/Features/Account/Auth/Components/AccountInlineFeedback.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Components/AccountInlineFeedback.swift
@@ -1,0 +1,22 @@
+//
+//  AccountInlineFeedback.swift
+//  CineMate
+//
+//  Created by OpenAI Codex on 2026-06-03.
+//
+
+import SwiftUI
+
+/// Small feedback model used by account sections to render local success or error messages.
+struct AccountInlineFeedback {
+    let message: String
+    let color: Color
+    
+    static func success(_ message: String) -> Self {
+        Self(message: message, color: .appPositive)
+    }
+    
+    static func error(_ message: String) -> Self {
+        Self(message: message, color: .appDestructive)
+    }
+}

--- a/CineMate/CineMate/Features/Account/Auth/Components/AccountLegalSectionView.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Components/AccountLegalSectionView.swift
@@ -7,9 +7,11 @@
 
 import SwiftUI
 
-/// Legal acceptance section for viewing current status and accepting newer terms.
+/// Shows legal acceptance status, stored versions, and local feedback for terms actions.
 struct AccountLegalSectionView: View {
-    let summaryText: String?
+    let status: AccountLegalStatus
+    let acceptedTermsVersionText: String?
+    let acceptedPrivacyVersionText: String?
     let shouldShowAcceptLatest: Bool
     let isAuthenticating: Bool
     let feedbackMessage: String?
@@ -20,12 +22,25 @@ struct AccountLegalSectionView: View {
     
     var body: some View {
         Section("Legal") {
-            if let summaryText {
-                Text(summaryText)
-                    .foregroundStyle(Color.appTextSecondary)
-            } else {
-                Text("No saved legal acceptance for this account yet.")
-                    .foregroundStyle(Color.appTextSecondary)
+            statusHeader(
+                title: status.title,
+                detail: status.detail,
+                iconSystemName: status.iconSystemName,
+                tint: status.tint
+            )
+            
+            VStack(alignment: .leading, spacing: SharedUI.Spacing.xSmall) {
+                if let acceptedTermsVersionText {
+                    metadataRow(title: "Terms", value: acceptedTermsVersionText)
+                }
+                
+                if let acceptedPrivacyVersionText {
+                    metadataRow(title: "Privacy", value: acceptedPrivacyVersionText)
+                }
+                
+                if let acceptedAtText = status.acceptedAtText {
+                    metadataRow(title: "Accepted", value: acceptedAtText)
+                }
             }
             
             Button("View terms", action: onViewTerms)
@@ -44,7 +59,7 @@ struct AccountLegalSectionView: View {
                     }
                 }
                 .buttonStyle(.borderedProminent)
-                .tint(.appPrimaryAction)
+                .tint(Color.appPrimaryAction)
                 .disabled(isAuthenticating)
             }
             
@@ -54,6 +69,50 @@ struct AccountLegalSectionView: View {
                     .foregroundStyle(feedbackColor)
                     .fixedSize(horizontal: false, vertical: true)
             }
+        }
+    }
+}
+
+private extension AccountLegalSectionView {
+    @ViewBuilder
+    func statusHeader(
+        title: String,
+        detail: String,
+        iconSystemName: String,
+        tint: Color
+    ) -> some View {
+        HStack(alignment: .top, spacing: SharedUI.Spacing.medium) {
+            Image(systemName: iconSystemName)
+                .font(.title3)
+                .foregroundStyle(tint)
+                .frame(width: SharedUI.Size.iconButton)
+            
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Color.appTextPrimary)
+                
+                Text(detail)
+                    .font(.footnote)
+                    .foregroundStyle(Color.appTextSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+    
+    @ViewBuilder
+    func metadataRow(title: String, value: String) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(title)
+                .font(.footnote.weight(.medium))
+                .foregroundStyle(Color.appTextSecondary)
+            
+            Spacer(minLength: SharedUI.Spacing.large)
+            
+            Text(value)
+                .font(.footnote)
+                .foregroundStyle(Color.appTextPrimary)
+                .multilineTextAlignment(.trailing)
         }
     }
 }

--- a/CineMate/CineMate/Features/Account/Auth/Components/AccountLegalSectionView.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Components/AccountLegalSectionView.swift
@@ -7,11 +7,12 @@
 
 import SwiftUI
 
-/// Shows legal acceptance status, stored versions, and local feedback for terms actions.
+/// Shows legal acceptance status, stored versions, refresh metadata, and local feedback.
 struct AccountLegalSectionView: View {
     let status: AccountLegalStatus
     let acceptedTermsVersionText: String?
     let acceptedPrivacyVersionText: String?
+    let lastCheckedText: String?
     let shouldShowAcceptLatest: Bool
     let isAuthenticating: Bool
     let feedbackMessage: String?
@@ -40,6 +41,10 @@ struct AccountLegalSectionView: View {
                 
                 if let acceptedAtText = status.acceptedAtText {
                     metadataRow(title: "Accepted", value: acceptedAtText)
+                }
+                
+                if let lastCheckedText {
+                    metadataRow(title: "Last checked", value: lastCheckedText)
                 }
             }
             

--- a/CineMate/CineMate/Features/Account/Auth/Components/AccountLegalSectionView.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Components/AccountLegalSectionView.swift
@@ -12,6 +12,9 @@ struct AccountLegalSectionView: View {
     let summaryText: String?
     let shouldShowAcceptLatest: Bool
     let isAuthenticating: Bool
+    let feedbackMessage: String?
+    let feedbackColor: Color?
+    let isAcceptingLatestTerms: Bool
     let onViewTerms: () -> Void
     let onAcceptLatest: () -> Void
     
@@ -30,10 +33,26 @@ struct AccountLegalSectionView: View {
                 .disabled(isAuthenticating)
             
             if shouldShowAcceptLatest {
-                Button("Accept latest", action: onAcceptLatest)
-                    .buttonStyle(.borderedProminent)
-                    .tint(.appPrimaryAction)
-                    .disabled(isAuthenticating)
+                Button(action: onAcceptLatest) {
+                    if isAcceptingLatestTerms {
+                        HStack(spacing: SharedUI.Spacing.small) {
+                            ProgressView()
+                            Text("Saving acceptance...")
+                        }
+                    } else {
+                        Text("Accept latest")
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.appPrimaryAction)
+                .disabled(isAuthenticating)
+            }
+            
+            if let feedbackMessage, let feedbackColor {
+                Text(feedbackMessage)
+                    .font(.footnote)
+                    .foregroundStyle(feedbackColor)
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
     }

--- a/CineMate/CineMate/Features/Account/Auth/Components/AccountLegalSectionView.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Components/AccountLegalSectionView.swift
@@ -1,0 +1,40 @@
+//
+//  AccountLegalSectionView.swift
+//  CineMate
+//
+//  Created by OpenAI Codex on 2026-06-03.
+//
+
+import SwiftUI
+
+/// Legal acceptance section for viewing current status and accepting newer terms.
+struct AccountLegalSectionView: View {
+    let summaryText: String?
+    let shouldShowAcceptLatest: Bool
+    let isAuthenticating: Bool
+    let onViewTerms: () -> Void
+    let onAcceptLatest: () -> Void
+    
+    var body: some View {
+        Section("Legal") {
+            if let summaryText {
+                Text(summaryText)
+                    .foregroundStyle(Color.appTextSecondary)
+            } else {
+                Text("No saved legal acceptance for this account yet.")
+                    .foregroundStyle(Color.appTextSecondary)
+            }
+            
+            Button("View terms", action: onViewTerms)
+                .buttonStyle(.bordered)
+                .disabled(isAuthenticating)
+            
+            if shouldShowAcceptLatest {
+                Button("Accept latest", action: onAcceptLatest)
+                    .buttonStyle(.borderedProminent)
+                    .tint(.appPrimaryAction)
+                    .disabled(isAuthenticating)
+            }
+        }
+    }
+}

--- a/CineMate/CineMate/Features/Account/Auth/Components/AccountLegalStatus.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Components/AccountLegalStatus.swift
@@ -1,0 +1,38 @@
+//
+//  AccountLegalStatus.swift
+//  CineMate
+//
+//  Created by OpenAI Codex on 2026-06-03.
+//
+
+import SwiftUI
+
+/// Maps legal acceptance state into concise copy, icon, and tint for the account UI.
+struct AccountLegalStatus {
+    let title: String
+    let detail: String
+    let acceptedAtText: String?
+    let iconSystemName: String
+    let tint: Color
+    
+    init(summaryText: String?, acceptedAtText: String?, isOutdated: Bool) {
+        self.acceptedAtText = acceptedAtText
+        
+        if summaryText == nil {
+            title = "Missing"
+            detail = "No saved legal acceptance for this account yet."
+            iconSystemName = "exclamationmark.circle.fill"
+            tint = Color.appDestructive
+        } else if isOutdated {
+            title = "Outdated"
+            detail = "Review and accept the latest terms to keep your account up to date."
+            iconSystemName = "clock.badge.exclamationmark.fill"
+            tint = AuthTheme.warningOnCurtain
+        } else {
+            title = "Accepted"
+            detail = "Your saved legal acceptance is current."
+            iconSystemName = "checkmark.seal.fill"
+            tint = Color.appPositive
+        }
+    }
+}

--- a/CineMate/CineMate/Features/Account/Auth/Components/AccountSecuritySectionView.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Components/AccountSecuritySectionView.swift
@@ -21,7 +21,7 @@ struct AccountSecuritySectionView: View {
     let isSendingPasswordReset: Bool
     let onChangeEmail: () -> Void
     let onChangePassword: () -> Void
-
+    
     var body: some View {
         Section("Security") {
             statusHeader(
@@ -30,29 +30,29 @@ struct AccountSecuritySectionView: View {
                 iconSystemName: status.iconSystemName,
                 tint: status.tint
             )
-
+            
             if let currentEmail {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Current email")
                         .font(.subheadline.weight(.medium))
                         .foregroundStyle(Color.appTextSecondary)
-
+                    
                     Text(currentEmail)
                         .textSelection(.enabled)
                         .foregroundStyle(Color.appTextSecondary)
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }
-
+            
             if canChangeEmail {
                 Text("Send a verification link before changing your account email.")
                     .font(.footnote)
                     .foregroundStyle(Color.appTextSecondary)
-
+                
                 Button("Change email", action: onChangeEmail)
                     .buttonStyle(.bordered)
                     .disabled(isAuthenticating)
-
+                
                 if let changeEmailFeedbackMessage, let changeEmailFeedbackColor {
                     Text(changeEmailFeedbackMessage)
                         .font(.footnote)
@@ -63,7 +63,7 @@ struct AccountSecuritySectionView: View {
                 Text("Email change is only available for email accounts.")
                     .foregroundStyle(Color.appTextSecondary)
             }
-
+            
             if canSendPasswordReset {
                 if let currentEmail {
                     Text("Password reset links are sent to \(currentEmail).")
@@ -71,7 +71,7 @@ struct AccountSecuritySectionView: View {
                         .foregroundStyle(Color.appTextSecondary)
                         .fixedSize(horizontal: false, vertical: true)
                 }
-
+                
                 Button(action: onChangePassword) {
                     if isSendingPasswordReset {
                         HStack(spacing: SharedUI.Spacing.small) {
@@ -79,12 +79,12 @@ struct AccountSecuritySectionView: View {
                             Text("Sending reset link...")
                         }
                     } else {
-                        Text("Change password")
+                        Text("Send reset link")
                     }
                 }
                 .buttonStyle(.bordered)
                 .disabled(isAuthenticating)
-
+                
                 if let passwordResetFeedbackMessage, let passwordResetFeedbackColor {
                     Text(passwordResetFeedbackMessage)
                         .font(.footnote)
@@ -112,12 +112,12 @@ private extension AccountSecuritySectionView {
                 .font(.title3)
                 .foregroundStyle(tint)
                 .frame(width: SharedUI.Size.iconButton)
-
+            
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(Color.appTextPrimary)
-
+                
                 Text(detail)
                     .font(.footnote)
                     .foregroundStyle(Color.appTextSecondary)

--- a/CineMate/CineMate/Features/Account/Auth/Components/AccountSecuritySectionView.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Components/AccountSecuritySectionView.swift
@@ -7,10 +7,10 @@
 
 import SwiftUI
 
-/// Security actions for email-based accounts.
-/// The parent view handles the async work and passes simple action closures into this section.
+/// Shows security status and local feedback while AccountView owns async auth actions.
 struct AccountSecuritySectionView: View {
     let currentEmail: String?
+    let status: AccountSecurityStatus
     let canChangeEmail: Bool
     let canSendPasswordReset: Bool
     let isAuthenticating: Bool
@@ -21,24 +21,38 @@ struct AccountSecuritySectionView: View {
     let isSendingPasswordReset: Bool
     let onChangeEmail: () -> Void
     let onChangePassword: () -> Void
-    
+
     var body: some View {
         Section("Security") {
+            statusHeader(
+                title: status.title,
+                detail: status.detail,
+                iconSystemName: status.iconSystemName,
+                tint: status.tint
+            )
+
             if let currentEmail {
-                HStack {
+                VStack(alignment: .leading, spacing: 2) {
                     Text("Current email")
-                    Spacer()
-                    Text(currentEmail)
+                        .font(.subheadline.weight(.medium))
                         .foregroundStyle(Color.appTextSecondary)
-                        .multilineTextAlignment(.trailing)
+
+                    Text(currentEmail)
+                        .textSelection(.enabled)
+                        .foregroundStyle(Color.appTextSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
             }
-            
+
             if canChangeEmail {
+                Text("Send a verification link before changing your account email.")
+                    .font(.footnote)
+                    .foregroundStyle(Color.appTextSecondary)
+
                 Button("Change email", action: onChangeEmail)
                     .buttonStyle(.bordered)
                     .disabled(isAuthenticating)
-                
+
                 if let changeEmailFeedbackMessage, let changeEmailFeedbackColor {
                     Text(changeEmailFeedbackMessage)
                         .font(.footnote)
@@ -49,13 +63,15 @@ struct AccountSecuritySectionView: View {
                 Text("Email change is only available for email accounts.")
                     .foregroundStyle(Color.appTextSecondary)
             }
-            
+
             if canSendPasswordReset {
                 if let currentEmail {
-                    Text("Reset links are sent to \(currentEmail).")
+                    Text("Password reset links are sent to \(currentEmail).")
+                        .font(.footnote)
                         .foregroundStyle(Color.appTextSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
-                
+
                 Button(action: onChangePassword) {
                     if isSendingPasswordReset {
                         HStack(spacing: SharedUI.Spacing.small) {
@@ -68,7 +84,7 @@ struct AccountSecuritySectionView: View {
                 }
                 .buttonStyle(.bordered)
                 .disabled(isAuthenticating)
-                
+
                 if let passwordResetFeedbackMessage, let passwordResetFeedbackColor {
                     Text(passwordResetFeedbackMessage)
                         .font(.footnote)
@@ -78,6 +94,34 @@ struct AccountSecuritySectionView: View {
             } else {
                 Text("Password reset is only available for email accounts.")
                     .foregroundStyle(Color.appTextSecondary)
+            }
+        }
+    }
+}
+
+private extension AccountSecuritySectionView {
+    @ViewBuilder
+    func statusHeader(
+        title: String,
+        detail: String,
+        iconSystemName: String,
+        tint: Color
+    ) -> some View {
+        HStack(alignment: .top, spacing: SharedUI.Spacing.medium) {
+            Image(systemName: iconSystemName)
+                .font(.title3)
+                .foregroundStyle(tint)
+                .frame(width: SharedUI.Size.iconButton)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Color.appTextPrimary)
+
+                Text(detail)
+                    .font(.footnote)
+                    .foregroundStyle(Color.appTextSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
     }

--- a/CineMate/CineMate/Features/Account/Auth/Components/AccountSecuritySectionView.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Components/AccountSecuritySectionView.swift
@@ -14,6 +14,11 @@ struct AccountSecuritySectionView: View {
     let canChangeEmail: Bool
     let canSendPasswordReset: Bool
     let isAuthenticating: Bool
+    let changeEmailFeedbackMessage: String?
+    let changeEmailFeedbackColor: Color?
+    let passwordResetFeedbackMessage: String?
+    let passwordResetFeedbackColor: Color?
+    let isSendingPasswordReset: Bool
     let onChangeEmail: () -> Void
     let onChangePassword: () -> Void
     
@@ -33,6 +38,13 @@ struct AccountSecuritySectionView: View {
                 Button("Change email", action: onChangeEmail)
                     .buttonStyle(.bordered)
                     .disabled(isAuthenticating)
+                
+                if let changeEmailFeedbackMessage, let changeEmailFeedbackColor {
+                    Text(changeEmailFeedbackMessage)
+                        .font(.footnote)
+                        .foregroundStyle(changeEmailFeedbackColor)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             } else {
                 Text("Email change is only available for email accounts.")
                     .foregroundStyle(Color.appTextSecondary)
@@ -44,9 +56,25 @@ struct AccountSecuritySectionView: View {
                         .foregroundStyle(Color.appTextSecondary)
                 }
                 
-                Button("Change password", action: onChangePassword)
-                    .buttonStyle(.bordered)
-                    .disabled(isAuthenticating)
+                Button(action: onChangePassword) {
+                    if isSendingPasswordReset {
+                        HStack(spacing: SharedUI.Spacing.small) {
+                            ProgressView()
+                            Text("Sending reset link...")
+                        }
+                    } else {
+                        Text("Change password")
+                    }
+                }
+                .buttonStyle(.bordered)
+                .disabled(isAuthenticating)
+                
+                if let passwordResetFeedbackMessage, let passwordResetFeedbackColor {
+                    Text(passwordResetFeedbackMessage)
+                        .font(.footnote)
+                        .foregroundStyle(passwordResetFeedbackColor)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             } else {
                 Text("Password reset is only available for email accounts.")
                     .foregroundStyle(Color.appTextSecondary)

--- a/CineMate/CineMate/Features/Account/Auth/Components/AccountSecuritySectionView.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Components/AccountSecuritySectionView.swift
@@ -1,0 +1,56 @@
+//
+//  AccountSecuritySectionView.swift
+//  CineMate
+//
+//  Created by OpenAI Codex on 2026-06-03.
+//
+
+import SwiftUI
+
+/// Security actions for email-based accounts.
+/// The parent view handles the async work and passes simple action closures into this section.
+struct AccountSecuritySectionView: View {
+    let currentEmail: String?
+    let canChangeEmail: Bool
+    let canSendPasswordReset: Bool
+    let isAuthenticating: Bool
+    let onChangeEmail: () -> Void
+    let onChangePassword: () -> Void
+    
+    var body: some View {
+        Section("Security") {
+            if let currentEmail {
+                HStack {
+                    Text("Current email")
+                    Spacer()
+                    Text(currentEmail)
+                        .foregroundStyle(Color.appTextSecondary)
+                        .multilineTextAlignment(.trailing)
+                }
+            }
+            
+            if canChangeEmail {
+                Button("Change email", action: onChangeEmail)
+                    .buttonStyle(.bordered)
+                    .disabled(isAuthenticating)
+            } else {
+                Text("Email change is only available for email accounts.")
+                    .foregroundStyle(Color.appTextSecondary)
+            }
+            
+            if canSendPasswordReset {
+                if let currentEmail {
+                    Text("Reset links are sent to \(currentEmail).")
+                        .foregroundStyle(Color.appTextSecondary)
+                }
+                
+                Button("Change password", action: onChangePassword)
+                    .buttonStyle(.bordered)
+                    .disabled(isAuthenticating)
+            } else {
+                Text("Password reset is only available for email accounts.")
+                    .foregroundStyle(Color.appTextSecondary)
+            }
+        }
+    }
+}

--- a/CineMate/CineMate/Features/Account/Auth/Components/AccountSecurityStatus.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Components/AccountSecurityStatus.swift
@@ -1,0 +1,30 @@
+//
+//  AccountSecurityStatus.swift
+//  CineMate
+//
+//  Created by OpenAI Codex on 2026-06-03.
+//
+
+import SwiftUI
+
+/// Maps available security actions into concise copy, icon, and tint for the account UI.
+struct AccountSecurityStatus {
+    let title: String
+    let detail: String
+    let iconSystemName: String
+    let tint: Color
+    
+    init(canChangeEmail: Bool, canSendPasswordReset: Bool) {
+        if canChangeEmail && canSendPasswordReset {
+            title = "Email account"
+            detail = "Email changes and password reset links are available for this account."
+            iconSystemName = "checkmark.shield.fill"
+            tint = Color.appPositive
+        } else {
+            title = "Limited controls"
+            detail = "Some security actions are only available for email sign in."
+            iconSystemName = "info.circle.fill"
+            tint = Color.appTextSecondary
+        }
+    }
+}

--- a/CineMate/CineMate/Features/Account/Auth/Components/AccountSessionSectionView.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Components/AccountSessionSectionView.swift
@@ -1,0 +1,24 @@
+//
+//  AccountSessionSectionView.swift
+//  CineMate
+//
+//  Created by OpenAI Codex on 2026-06-03.
+//
+
+import SwiftUI
+
+/// Session control section for ending a guest session or signing out of a full account.
+struct AccountSessionSectionView: View {
+    let isGuest: Bool
+    let isAuthenticating: Bool
+    let onSignOut: () -> Void
+    
+    var body: some View {
+        Section("Session") {
+            Button(isGuest ? "End guest session" : "Sign out", action: onSignOut)
+                .buttonStyle(.borderedProminent)
+                .tint(.appPrimaryAction)
+                .disabled(isAuthenticating)
+        }
+    }
+}

--- a/CineMate/CineMate/Features/Account/Auth/Components/AccountSummaryContent.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Components/AccountSummaryContent.swift
@@ -1,0 +1,53 @@
+//
+//  AccountSummaryContent.swift
+//  CineMate
+//
+//  Created by OpenAI Codex on 2026-06-03.
+//
+
+import Foundation
+
+/// Presentation data for the account summary card.
+/// It converts auth session state into stable text and icon values for the summary view.
+struct AccountSummaryContent {
+    let title: String
+    let detail: String?
+    let iconSystemName: String
+    let providerDescription: String
+    let userID: String?
+    
+    init(
+        isSignedIn: Bool,
+        isGuest: Bool,
+        currentUserEmail: String?,
+        providerDescription: String,
+        currentUID: String?
+    ) {
+        if let currentUserEmail, !currentUserEmail.isEmpty {
+            title = currentUserEmail
+        } else if isGuest {
+            title = "Guest account"
+        } else {
+            title = isSignedIn ? "Signed in" : "Signed out"
+        }
+        
+        if isGuest {
+            detail = "Create an account to manage your details and unlock more features."
+        } else if isSignedIn {
+            detail = "Manage your email, security, and legal settings."
+        } else {
+            detail = "Sign in to manage your account."
+        }
+        
+        if isGuest {
+            iconSystemName = "person.crop.circle.badge.questionmark"
+        } else {
+            iconSystemName = isSignedIn
+            ? "person.crop.circle.fill"
+            : "person.crop.circle.badge.xmark"
+        }
+        
+        self.providerDescription = providerDescription
+        userID = currentUID.map { String($0.prefix(10)) }
+    }
+}

--- a/CineMate/CineMate/Features/Account/Auth/Components/AccountSummarySectionView.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Components/AccountSummarySectionView.swift
@@ -8,13 +8,17 @@
 import SwiftUI
 
 /// Top account summary shown above the detailed account sections.
-/// It is designed to handle long provider labels and email values without truncation-heavy layouts.
+/// It delegates copy actions so pasteboard and toast ownership stay in AccountView.
 struct AccountSummarySectionView: View {
     let title: String
     let detail: String?
     let iconSystemName: String
     let providerDescription: String
     let userID: String?
+    let copyEmail: String?
+    let copyUserID: String?
+    let onCopyEmail: (String) -> Void
+    let onCopyUserID: (String) -> Void
     
     var body: some View {
         VStack(alignment: .leading, spacing: SharedUI.Spacing.small) {
@@ -35,13 +39,24 @@ struct AccountSummarySectionView: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
             
+            if let copyEmail {
+                copyButton(
+                    title: "Copy email",
+                    value: copyEmail,
+                    action: onCopyEmail
+                )
+            }
+            
             summaryRow(title: "Sign-in method", value: providerDescription)
             
             if let userID {
                 summaryRow(
                     title: "User ID",
                     value: userID,
-                    usesMonospacedValue: true
+                    usesMonospacedValue: true,
+                    copyValue: copyUserID,
+                    copyLabel: "Copy user ID",
+                    onCopy: onCopyUserID
                 )
             }
         }
@@ -54,12 +69,27 @@ private extension AccountSummarySectionView {
     func summaryRow(
         title: String,
         value: String,
-        usesMonospacedValue: Bool = false
+        usesMonospacedValue: Bool = false,
+        copyValue: String? = nil,
+        copyLabel: String? = nil,
+        onCopy: ((String) -> Void)? = nil
     ) -> some View {
         VStack(alignment: .leading, spacing: 2) {
-            Text(title)
-                .font(.subheadline.weight(.medium))
-                .foregroundStyle(Color.appTextSecondary)
+            HStack(alignment: .center, spacing: SharedUI.Spacing.small) {
+                Text(title)
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(Color.appTextSecondary)
+                
+                Spacer(minLength: SharedUI.Spacing.medium)
+                
+                if let copyValue, let copyLabel, let onCopy {
+                    copyButton(
+                        title: copyLabel,
+                        value: copyValue,
+                        action: onCopy
+                    )
+                }
+            }
             
             Text(value)
                 .font(usesMonospacedValue ? .footnote.monospaced() : .body)
@@ -68,5 +98,22 @@ private extension AccountSummarySectionView {
                 .fixedSize(horizontal: false, vertical: true)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
+    }
+    
+    @ViewBuilder
+    func copyButton(
+        title: String,
+        value: String,
+        action: @escaping (String) -> Void
+    ) -> some View {
+        Button {
+            action(value)
+        } label: {
+            Label(title, systemImage: "doc.on.doc")
+                .font(.footnote.weight(.medium))
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+        .tint(Color.appPrimaryAction)
     }
 }

--- a/CineMate/CineMate/Features/Account/Auth/Components/AccountSummarySectionView.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Components/AccountSummarySectionView.swift
@@ -1,0 +1,72 @@
+//
+//  AccountSummarySectionView.swift
+//  CineMate
+//
+//  Created by OpenAI Codex on 2026-06-03.
+//
+
+import SwiftUI
+
+/// Top account summary shown above the detailed account sections.
+/// It is designed to handle long provider labels and email values without truncation-heavy layouts.
+struct AccountSummarySectionView: View {
+    let title: String
+    let detail: String?
+    let iconSystemName: String
+    let providerDescription: String
+    let userID: String?
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: SharedUI.Spacing.small) {
+            HStack(alignment: .center, spacing: SharedUI.Spacing.medium) {
+                Image(systemName: iconSystemName)
+                    .font(.title2)
+                    .foregroundStyle(Color.appPrimaryAction)
+                
+                Text(title)
+                    .font(.headline)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+            }
+            
+            if let detail {
+                Text(detail)
+                    .foregroundStyle(Color.appTextSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            
+            summaryRow(title: "Sign-in method", value: providerDescription)
+            
+            if let userID {
+                summaryRow(
+                    title: "User ID",
+                    value: userID,
+                    usesMonospacedValue: true
+                )
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+private extension AccountSummarySectionView {
+    @ViewBuilder
+    func summaryRow(
+        title: String,
+        value: String,
+        usesMonospacedValue: Bool = false
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(Color.appTextSecondary)
+            
+            Text(value)
+                .font(usesMonospacedValue ? .footnote.monospaced() : .body)
+                .foregroundStyle(Color.appTextPrimary)
+                .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}

--- a/CineMate/CineMate/Features/Account/Auth/Components/GuestAccountSectionView.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Components/GuestAccountSectionView.swift
@@ -1,0 +1,26 @@
+//
+//  GuestAccountSectionView.swift
+//  CineMate
+//
+//  Created by OpenAI Codex on 2026-06-03.
+//
+
+import SwiftUI
+
+/// Upgrade prompt shown for guest sessions inside the account screen.
+struct GuestAccountSectionView: View {
+    let isAuthenticating: Bool
+    let onCreateAccount: () -> Void
+    
+    var body: some View {
+        Section("Guest account") {
+            Text("Create an account to unlock Discover and Search.")
+                .foregroundStyle(Color.appTextSecondary)
+            
+            Button("Create Account", action: onCreateAccount)
+                .buttonStyle(.borderedProminent)
+                .tint(.appPrimaryAction)
+                .disabled(isAuthenticating)
+        }
+    }
+}

--- a/CineMate/CineMate/Features/Account/Auth/Components/GuestAccountSectionView.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Components/GuestAccountSectionView.swift
@@ -7,20 +7,60 @@
 
 import SwiftUI
 
-/// Upgrade prompt shown for guest sessions inside the account screen.
+/// Explains account value for guest users before routing to account creation.
 struct GuestAccountSectionView: View {
     let isAuthenticating: Bool
     let onCreateAccount: () -> Void
     
     var body: some View {
         Section("Guest account") {
-            Text("Create an account to unlock Discover and Search.")
-                .foregroundStyle(Color.appTextSecondary)
+            VStack(alignment: .leading, spacing: SharedUI.Spacing.medium) {
+                Label("Get more out of CineMate", systemImage: "sparkles")
+                    .font(.headline)
+                    .foregroundStyle(Color.appTextPrimary)
+                
+                Text("Create an account to unlock more features and keep your profile available across sessions.")
+                    .foregroundStyle(Color.appTextSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                
+                VStack(alignment: .leading, spacing: SharedUI.Spacing.small) {
+                    benefitRow(
+                        iconSystemName: "safari.fill",
+                        title: "Unlock Discover"
+                    )
+                    benefitRow(
+                        iconSystemName: "magnifyingglass",
+                        title: "Unlock Search"
+                    )
+                    benefitRow(
+                        iconSystemName: "lock.shield.fill",
+                        title: "Keep your data across sessions"
+                    )
+                }
+            }
+            .padding(.vertical, 2)
             
-            Button("Create Account", action: onCreateAccount)
+            Button("Create account and unlock features", action: onCreateAccount)
                 .buttonStyle(.borderedProminent)
                 .tint(.appPrimaryAction)
                 .disabled(isAuthenticating)
+        }
+    }
+}
+
+private extension GuestAccountSectionView {
+    @ViewBuilder
+    func benefitRow(iconSystemName: String, title: String) -> some View {
+        HStack(alignment: .center, spacing: SharedUI.Spacing.medium) {
+            Image(systemName: iconSystemName)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(Color.appPrimaryAction)
+                .frame(width: SharedUI.Size.iconButton, alignment: .center)
+            
+            Text(title)
+                .font(.subheadline)
+                .foregroundStyle(Color.appTextPrimary)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 }

--- a/CineMate/CineMate/Features/Account/Auth/Views/AccountView+Feedback.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Views/AccountView+Feedback.swift
@@ -14,7 +14,7 @@ extension AccountView {
     func handleChangeEmailResult(_ result: AuthViewModel.ChangeEmailResult) {
         switch result {
         case .verificationSent(let email):
-            changeEmailFeedback = .success("Verification link sent to \(email).")
+            changeEmailFeedback = .success("Verification link sent to \(email). Check your inbox.")
             authViewModel.errorMessage = nil
         case .unavailable:
             changeEmailFeedback = .error("Email change is only available for email sign in.")
@@ -35,7 +35,7 @@ extension AccountView {
     func handleAcceptTermsResult(_ result: AuthViewModel.AcceptTermsResult) {
         switch result {
         case .saved:
-            legalFeedback = .success("Accepted terms version \(TermsContent.currentVersion).")
+            legalFeedback = .success("Legal status updated to terms \(TermsContent.currentVersion).")
             authViewModel.errorMessage = nil
         case .unavailable:
             legalFeedback = .error("Terms acceptance not available for this account.")

--- a/CineMate/CineMate/Features/Account/Auth/Views/AccountView+Feedback.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Views/AccountView+Feedback.swift
@@ -1,0 +1,40 @@
+//
+//  AccountView+Feedback.swift
+//  CineMate
+//
+//  Created by OpenAI Codex on 2026-06-03.
+//
+
+import SwiftUI
+
+/// Feedback helpers kept outside the main view file.
+/// They map async account results to short toast messages without changing view state ownership.
+extension AccountView {
+    /// Maps change email results to short user-facing feedback.
+    func handleChangeEmailResult(_ result: AuthViewModel.ChangeEmailResult) {
+        switch result {
+        case .verificationSent(let email):
+            toastCenter.show("Verification link sent to \(email).")
+        case .unavailable:
+            toastCenter.show("Email change is only available for email sign in.")
+        case .cooldown(let seconds):
+            toastCenter.show("Wait \(seconds) seconds before sending another link.")
+        case .needsRecentLogin:
+            toastCenter.show("Please sign in again to change your email.")
+        case .failure(let message):
+            toastCenter.show(message)
+        }
+    }
+    
+    /// Maps terms acceptance results to short user-facing feedback.
+    func handleAcceptTermsResult(_ result: AuthViewModel.AcceptTermsResult) {
+        switch result {
+        case .saved:
+            toastCenter.show("Accepted terms version \(TermsContent.currentVersion).")
+        case .unavailable:
+            toastCenter.show("Terms acceptance not available for this account.")
+        case .failure(let message):
+            toastCenter.show(message)
+        }
+    }
+}

--- a/CineMate/CineMate/Features/Account/Auth/Views/AccountView+Feedback.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Views/AccountView+Feedback.swift
@@ -8,21 +8,26 @@
 import SwiftUI
 
 /// Feedback helpers kept outside the main view file.
-/// They map async account results to short toast messages without changing view state ownership.
+/// They map async account results to local section feedback without changing view state ownership.
 extension AccountView {
     /// Maps change email results to short user-facing feedback.
     func handleChangeEmailResult(_ result: AuthViewModel.ChangeEmailResult) {
         switch result {
         case .verificationSent(let email):
-            toastCenter.show("Verification link sent to \(email).")
+            changeEmailFeedback = .success("Verification link sent to \(email).")
+            authViewModel.errorMessage = nil
         case .unavailable:
-            toastCenter.show("Email change is only available for email sign in.")
+            changeEmailFeedback = .error("Email change is only available for email sign in.")
+            authViewModel.errorMessage = nil
         case .cooldown(let seconds):
-            toastCenter.show("Wait \(seconds) seconds before sending another link.")
+            changeEmailFeedback = .error("Wait \(seconds) seconds before sending another link.")
+            authViewModel.errorMessage = nil
         case .needsRecentLogin:
-            toastCenter.show("Please sign in again to change your email.")
+            changeEmailFeedback = .error("Please sign in again to change your email.")
+            authViewModel.errorMessage = nil
         case .failure(let message):
-            toastCenter.show(message)
+            changeEmailFeedback = .error(message)
+            authViewModel.errorMessage = nil
         }
     }
     
@@ -30,11 +35,14 @@ extension AccountView {
     func handleAcceptTermsResult(_ result: AuthViewModel.AcceptTermsResult) {
         switch result {
         case .saved:
-            toastCenter.show("Accepted terms version \(TermsContent.currentVersion).")
+            legalFeedback = .success("Accepted terms version \(TermsContent.currentVersion).")
+            authViewModel.errorMessage = nil
         case .unavailable:
-            toastCenter.show("Terms acceptance not available for this account.")
+            legalFeedback = .error("Terms acceptance not available for this account.")
+            authViewModel.errorMessage = nil
         case .failure(let message):
-            toastCenter.show(message)
+            legalFeedback = .error(message)
+            authViewModel.errorMessage = nil
         }
     }
 }

--- a/CineMate/CineMate/Features/Account/Auth/Views/AccountView.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Views/AccountView.swift
@@ -10,12 +10,17 @@ import SwiftUI
 /// Account container that orchestrates account sections, sheets, and async auth actions.
 /// Child section views stay presentation-focused while this view owns navigation and toast flows.
 struct AccountView: View {
-    @ObservedObject private var authViewModel: AuthViewModel
+    @ObservedObject var authViewModel: AuthViewModel
     @EnvironmentObject private var navigator: AppNavigator
     @EnvironmentObject var toastCenter: ToastCenter
     @Environment(\.scenePhase) private var scenePhase
     @State private var isShowingChangeEmailSheet = false
     @State private var isShowingTermsSheet = false
+    @State var changeEmailFeedback: AccountInlineFeedback?
+    @State var passwordResetFeedback: AccountInlineFeedback?
+    @State var legalFeedback: AccountInlineFeedback?
+    @State var isSendingPasswordReset = false
+    @State var isAcceptingLatestTerms = false
     
     init(viewModel: AuthViewModel) {
         self._authViewModel = ObservedObject(wrappedValue: viewModel)
@@ -34,6 +39,17 @@ struct AccountView: View {
                     )
                 }
                 
+                if let errorMessage = authViewModel.errorMessage, changeEmailFeedback == nil, passwordResetFeedback == nil, legalFeedback == nil {
+                    Section {
+                        AccountErrorMessageView(
+                            message: errorMessage,
+                            onDismiss: {
+                                authViewModel.errorMessage = nil
+                            }
+                        )
+                    }
+                }
+                
                 if authViewModel.isSignedIn {
                     if authViewModel.isGuest {
                         GuestAccountSectionView(
@@ -49,19 +65,32 @@ struct AccountView: View {
                             currentEmail: authViewModel.currentUserEmail,
                             canChangeEmail: authViewModel.canChangeEmail,
                             canSendPasswordReset: authViewModel.canSendPasswordReset,
-                            isAuthenticating: authViewModel.isAuthenticating,
+                            isAuthenticating: isSendingPasswordReset,
+                            changeEmailFeedbackMessage: changeEmailFeedback?.message,
+                            changeEmailFeedbackColor: changeEmailFeedback?.color,
+                            passwordResetFeedbackMessage: passwordResetFeedback?.message,
+                            passwordResetFeedbackColor: passwordResetFeedback?.color,
+                            isSendingPasswordReset: isSendingPasswordReset,
                             onChangeEmail: {
+                                changeEmailFeedback = nil
                                 isShowingChangeEmailSheet = true
                             },
                             onChangePassword: {
                                 Task {
+                                    isSendingPasswordReset = true
+                                    passwordResetFeedback = nil
+                                    defer { isSendingPasswordReset = false }
+                                    
                                     switch await authViewModel.sendPasswordResetForCurrentUser() {
                                     case .sent(let email):
-                                        toastCenter.show("Password reset link sent to \(email).")
+                                        passwordResetFeedback = .success("Password reset link sent to \(email).")
+                                        authViewModel.errorMessage = nil
                                     case .unavailable:
-                                        toastCenter.show("Password reset is only available for email sign in.")
+                                        passwordResetFeedback = .error("Password reset is only available for email sign in.")
+                                        authViewModel.errorMessage = nil
                                     case .failure(let message):
-                                        toastCenter.show(message)
+                                        passwordResetFeedback = .error(message)
+                                        authViewModel.errorMessage = nil
                                     }
                                 }
                             }
@@ -71,12 +100,19 @@ struct AccountView: View {
                             summaryText: authViewModel.acceptedTermsSummaryText,
                             shouldShowAcceptLatest: authViewModel.isAcceptedTermsOutdated
                             || authViewModel.acceptedTermsSummaryText == nil,
-                            isAuthenticating: authViewModel.isAuthenticating,
+                            isAuthenticating: isAcceptingLatestTerms,
+                            feedbackMessage: legalFeedback?.message,
+                            feedbackColor: legalFeedback?.color,
+                            isAcceptingLatestTerms: isAcceptingLatestTerms,
                             onViewTerms: {
                                 isShowingTermsSheet = true
                             },
                             onAcceptLatest: {
                                 Task {
+                                    isAcceptingLatestTerms = true
+                                    legalFeedback = nil
+                                    defer { isAcceptingLatestTerms = false }
+                                    
                                     let result = await authViewModel.acceptCurrentTermsVersion()
                                     handleAcceptTermsResult(result)
                                 }
@@ -115,7 +151,6 @@ struct AccountView: View {
                 }
             }
             .navigationTitle("Account")
-            .disabled(authViewModel.isAuthenticating)
             .sheet(isPresented: $isShowingChangeEmailSheet) {
                 ChangeEmailSheet(
                     currentEmail: authViewModel.currentUserEmail,
@@ -129,16 +164,6 @@ struct AccountView: View {
             }
             .sheet(isPresented: $isShowingTermsSheet) {
                 TermsSheet(markdown: TermsContent.termsMarkdown)
-            }
-            
-            if let error = authViewModel.errorMessage {
-                ErrorMessageView(
-                    title: "Authentication Error",
-                    message: error,
-                    onRetry: { authViewModel.errorMessage = nil }
-                )
-                .transition(.opacity)
-                .zIndex(1)
             }
         }
         .animation(.default, value: authViewModel.errorMessage != nil)

--- a/CineMate/CineMate/Features/Account/Auth/Views/AccountView.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Views/AccountView.swift
@@ -7,7 +7,8 @@
 
 import SwiftUI
 
-/// Account screen with session info and account actions.
+/// Account container that orchestrates account sections, sheets, and async auth actions.
+/// Child section views stay presentation-focused while this view owns navigation and toast flows.
 struct AccountView: View {
     @ObservedObject private var authViewModel: AuthViewModel
     @EnvironmentObject private var navigator: AppNavigator
@@ -23,134 +24,70 @@ struct AccountView: View {
     var body: some View {
         ZStack {
             Form {
-                Section("Session") {
-                    if let uid = authViewModel.currentUID {
-                        VStack(alignment: .leading, spacing: 6) {
-                            Label("Signed in", systemImage: "person.crop.circle.fill")
-                                .font(.headline)
-                            Text("User ID: \(uid.prefix(10))")
-                                .foregroundStyle(Color.appTextSecondary)
-                                .font(.footnote.monospaced())
-                        }
-                    } else {
-                        VStack(alignment: .leading, spacing: 6) {
-                            Label("Signed out", systemImage: "person.crop.circle.badge.xmark")
-                                .font(.headline)
-                            Text("Sign in to manage your account.")
-                                .foregroundStyle(Color.appTextSecondary)
-                        }
-                    }
+                Section {
+                    AccountSummarySectionView(
+                        title: accountSummaryTitle,
+                        detail: accountSummaryDetail,
+                        iconSystemName: accountSummaryIcon,
+                        providerDescription: authViewModel.authProviderDescription,
+                        userID: authViewModel.currentUID.map { String($0.prefix(10)) }
+                    )
                 }
 
                 if authViewModel.isSignedIn {
-                    Section("Provider") {
-                        HStack {
-                            Text("Sign-in method")
-                            Spacer()
-                            Text(authViewModel.authProviderDescription)
-                                .foregroundStyle(Color.appTextSecondary)
-                                .multilineTextAlignment(.trailing)
-                        }
-                    }
-
                     if authViewModel.isGuest {
-                        Section("Guest account") {
-                            Text("Create an account to unlock Discover and Search.")
-                                .foregroundStyle(Color.appTextSecondary)
-
-                            Button("Create Account") {
+                        GuestAccountSectionView(
+                            isAuthenticating: authViewModel.isAuthenticating,
+                            onCreateAccount: {
                                 navigator.goToCreateAccount()
                             }
-                            .buttonStyle(.borderedProminent)
-                            .tint(.appPrimaryAction)
-                            .disabled(authViewModel.isAuthenticating)
-                        }
+                        )
                     }
 
                     if !authViewModel.isGuest {
-                        Section("Email") {
-                            if let email = authViewModel.currentUserEmail {
-                                HStack {
-                                    Text("Current email")
-                                    Spacer()
-                                    Text(email)
-                                        .foregroundStyle(Color.appTextSecondary)
-                                        .multilineTextAlignment(.trailing)
+                        AccountSecuritySectionView(
+                            currentEmail: authViewModel.currentUserEmail,
+                            canChangeEmail: authViewModel.canChangeEmail,
+                            canSendPasswordReset: authViewModel.canSendPasswordReset,
+                            isAuthenticating: authViewModel.isAuthenticating,
+                            onChangeEmail: {
+                                isShowingChangeEmailSheet = true
+                            },
+                            onChangePassword: {
+                                Task {
+                                    switch await authViewModel.sendPasswordResetForCurrentUser() {
+                                    case .sent(let email):
+                                        toastCenter.show("Password reset link sent to \(email).")
+                                    case .unavailable:
+                                        toastCenter.show("Password reset is only available for email sign in.")
+                                    case .failure(let message):
+                                        toastCenter.show(message)
+                                    }
                                 }
                             }
+                        )
 
-                            if authViewModel.canChangeEmail {
-                                Button("Change email") {
-                                    isShowingChangeEmailSheet = true
-                                }
-                                .buttonStyle(.bordered)
-                                .disabled(authViewModel.isAuthenticating)
-                            } else {
-                                Text("Email change is only available for email accounts.")
-                                    .foregroundStyle(Color.appTextSecondary)
-                            }
-                        }
-                    }
-
-                    if !authViewModel.isGuest {
-                        Section("Legal") {
-                            if let summary = authViewModel.acceptedTermsSummaryText {
-                                Text(summary)
-                                    .foregroundStyle(Color.appTextSecondary)
-                            } else {
-                                Text("No saved legal acceptance for this account yet.")
-                                    .foregroundStyle(Color.appTextSecondary)
-                            }
-
-                            Button("View terms") {
+                        AccountLegalSectionView(
+                            summaryText: authViewModel.acceptedTermsSummaryText,
+                            shouldShowAcceptLatest: authViewModel.isAcceptedTermsOutdated
+                            || authViewModel.acceptedTermsSummaryText == nil,
+                            isAuthenticating: authViewModel.isAuthenticating,
+                            onViewTerms: {
                                 isShowingTermsSheet = true
-                            }
-                            .buttonStyle(.bordered)
-                            .disabled(authViewModel.isAuthenticating)
-
-                            if authViewModel.isAcceptedTermsOutdated || authViewModel.acceptedTermsSummaryText == nil {
-                                Button("Accept latest") {
-                                    Task {
-                                        let result = await authViewModel.acceptCurrentTermsVersion()
-                                        handleAcceptTermsResult(result)
-                                    }
+                            },
+                            onAcceptLatest: {
+                                Task {
+                                    let result = await authViewModel.acceptCurrentTermsVersion()
+                                    handleAcceptTermsResult(result)
                                 }
-                                .buttonStyle(.borderedProminent)
-                                .tint(.appPrimaryAction)
-                                .disabled(authViewModel.isAuthenticating)
                             }
-                        }
-
-                        Section("Security") {
-                            if authViewModel.canSendPasswordReset {
-                                if let email = authViewModel.currentUserEmail {
-                                    Text("Reset links are sent to \(email).")
-                                        .foregroundStyle(Color.appTextSecondary)
-                                }
-
-                                Button("Change password") {
-                                    Task {
-                                        switch await authViewModel.sendPasswordResetForCurrentUser() {
-                                        case .sent(let email):
-                                            toastCenter.show("Password reset link sent to \(email).")
-                                        case .unavailable:
-                                            toastCenter.show("Password reset is only available for email sign in.")
-                                        case .failure(let message):
-                                            toastCenter.show(message)
-                                        }
-                                    }
-                                }
-                                .buttonStyle(.bordered)
-                                .disabled(authViewModel.isAuthenticating)
-                            } else {
-                                Text("Password reset is only available for email accounts.")
-                                    .foregroundStyle(Color.appTextSecondary)
-                            }
-                        }
+                        )
                     }
 
-                    Section("Actions") {
-                        Button(authViewModel.isGuest ? "End guest session" : "Sign out") {
+                    AccountSessionSectionView(
+                        isGuest: authViewModel.isGuest,
+                        isAuthenticating: authViewModel.isAuthenticating,
+                        onSignOut: {
                             Task {
                                 let wasGuest = authViewModel.isGuest
                                 await authViewModel.signOut()
@@ -159,10 +96,7 @@ struct AccountView: View {
                                 }
                             }
                         }
-                        .buttonStyle(.borderedProminent)
-                        .tint(.appPrimaryAction)
-                        .disabled(authViewModel.isAuthenticating)
-                    }
+                    )
 
                     if !authViewModel.isGuest {
                         AccountDangerZoneView(
@@ -217,6 +151,35 @@ struct AccountView: View {
         }
     }
 
+    private var accountSummaryTitle: String {
+        if let email = authViewModel.currentUserEmail, !email.isEmpty {
+            return email
+        }
+        if authViewModel.isGuest {
+            return "Guest account"
+        }
+        return authViewModel.isSignedIn ? "Signed in" : "Signed out"
+    }
+
+    private var accountSummaryDetail: String? {
+        if authViewModel.isGuest {
+            return "Create an account to manage your details and unlock more features."
+        }
+        if authViewModel.isSignedIn {
+            return "Manage your email, security, and legal settings."
+        }
+        return "Sign in to manage your account."
+    }
+
+    private var accountSummaryIcon: String {
+        if authViewModel.isGuest {
+            return "person.crop.circle.badge.questionmark"
+        }
+        return authViewModel.isSignedIn
+        ? "person.crop.circle.fill"
+        : "person.crop.circle.badge.xmark"
+    }
+
     private func handleChangeEmailResult(_ result: AuthViewModel.ChangeEmailResult) {
         switch result {
         case .verificationSent(let email):
@@ -231,7 +194,8 @@ struct AccountView: View {
             toastCenter.show(message)
         }
     }
-
+    
+    /// Maps terms acceptance results to short user-facing feedback.
     private func handleAcceptTermsResult(_ result: AuthViewModel.AcceptTermsResult) {
         switch result {
         case .saved:

--- a/CineMate/CineMate/Features/Account/Auth/Views/AccountView.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Views/AccountView.swift
@@ -12,28 +12,28 @@ import SwiftUI
 struct AccountView: View {
     @ObservedObject private var authViewModel: AuthViewModel
     @EnvironmentObject private var navigator: AppNavigator
-    @EnvironmentObject private var toastCenter: ToastCenter
+    @EnvironmentObject var toastCenter: ToastCenter
     @Environment(\.scenePhase) private var scenePhase
     @State private var isShowingChangeEmailSheet = false
     @State private var isShowingTermsSheet = false
-
+    
     init(viewModel: AuthViewModel) {
         self._authViewModel = ObservedObject(wrappedValue: viewModel)
     }
-
+    
     var body: some View {
         ZStack {
             Form {
                 Section {
                     AccountSummarySectionView(
-                        title: accountSummaryTitle,
-                        detail: accountSummaryDetail,
-                        iconSystemName: accountSummaryIcon,
-                        providerDescription: authViewModel.authProviderDescription,
-                        userID: authViewModel.currentUID.map { String($0.prefix(10)) }
+                        title: accountSummaryContent.title,
+                        detail: accountSummaryContent.detail,
+                        iconSystemName: accountSummaryContent.iconSystemName,
+                        providerDescription: accountSummaryContent.providerDescription,
+                        userID: accountSummaryContent.userID
                     )
                 }
-
+                
                 if authViewModel.isSignedIn {
                     if authViewModel.isGuest {
                         GuestAccountSectionView(
@@ -43,7 +43,7 @@ struct AccountView: View {
                             }
                         )
                     }
-
+                    
                     if !authViewModel.isGuest {
                         AccountSecuritySectionView(
                             currentEmail: authViewModel.currentUserEmail,
@@ -66,7 +66,7 @@ struct AccountView: View {
                                 }
                             }
                         )
-
+                        
                         AccountLegalSectionView(
                             summaryText: authViewModel.acceptedTermsSummaryText,
                             shouldShowAcceptLatest: authViewModel.isAcceptedTermsOutdated
@@ -83,7 +83,7 @@ struct AccountView: View {
                             }
                         )
                     }
-
+                    
                     AccountSessionSectionView(
                         isGuest: authViewModel.isGuest,
                         isAuthenticating: authViewModel.isAuthenticating,
@@ -97,7 +97,7 @@ struct AccountView: View {
                             }
                         }
                     )
-
+                    
                     if !authViewModel.isGuest {
                         AccountDangerZoneView(
                             authViewModel: authViewModel,
@@ -130,7 +130,7 @@ struct AccountView: View {
             .sheet(isPresented: $isShowingTermsSheet) {
                 TermsSheet(markdown: TermsContent.termsMarkdown)
             }
-
+            
             if let error = authViewModel.errorMessage {
                 ErrorMessageView(
                     title: "Authentication Error",
@@ -150,61 +150,15 @@ struct AccountView: View {
             Task { await authViewModel.refreshCurrentUserFromServer() }
         }
     }
-
-    private var accountSummaryTitle: String {
-        if let email = authViewModel.currentUserEmail, !email.isEmpty {
-            return email
-        }
-        if authViewModel.isGuest {
-            return "Guest account"
-        }
-        return authViewModel.isSignedIn ? "Signed in" : "Signed out"
-    }
-
-    private var accountSummaryDetail: String? {
-        if authViewModel.isGuest {
-            return "Create an account to manage your details and unlock more features."
-        }
-        if authViewModel.isSignedIn {
-            return "Manage your email, security, and legal settings."
-        }
-        return "Sign in to manage your account."
-    }
-
-    private var accountSummaryIcon: String {
-        if authViewModel.isGuest {
-            return "person.crop.circle.badge.questionmark"
-        }
-        return authViewModel.isSignedIn
-        ? "person.crop.circle.fill"
-        : "person.crop.circle.badge.xmark"
-    }
-
-    private func handleChangeEmailResult(_ result: AuthViewModel.ChangeEmailResult) {
-        switch result {
-        case .verificationSent(let email):
-            toastCenter.show("Verification link sent to \(email).")
-        case .unavailable:
-            toastCenter.show("Email change is only available for email sign in.")
-        case .cooldown(let seconds):
-            toastCenter.show("Wait \(seconds) seconds before sending another link.")
-        case .needsRecentLogin:
-            toastCenter.show("Please sign in again to change your email.")
-        case .failure(let message):
-            toastCenter.show(message)
-        }
-    }
     
-    /// Maps terms acceptance results to short user-facing feedback.
-    private func handleAcceptTermsResult(_ result: AuthViewModel.AcceptTermsResult) {
-        switch result {
-        case .saved:
-            toastCenter.show("Accepted terms version \(TermsContent.currentVersion).")
-        case .unavailable:
-            toastCenter.show("Terms acceptance not available for this account.")
-        case .failure(let message):
-            toastCenter.show(message)
-        }
+    private var accountSummaryContent: AccountSummaryContent {
+        AccountSummaryContent(
+            isSignedIn: authViewModel.isSignedIn,
+            isGuest: authViewModel.isGuest,
+            currentUserEmail: authViewModel.currentUserEmail,
+            providerDescription: authViewModel.authProviderDescription,
+            currentUID: authViewModel.currentUID
+        )
     }
 }
 

--- a/CineMate/CineMate/Features/Account/Auth/Views/AccountView.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Views/AccountView.swift
@@ -6,8 +6,9 @@
 //
 
 import SwiftUI
+import UIKit
 
-/// Owns account navigation, sheet presentation, and local feedback for async auth actions.
+/// Owns account navigation, sheet presentation, copy actions, server refresh, and local feedback.
 /// Child section views stay presentation-focused.
 struct AccountView: View {
     @ObservedObject var authViewModel: AuthViewModel
@@ -21,6 +22,8 @@ struct AccountView: View {
     @State var legalFeedback: AccountInlineFeedback?
     @State var isSendingPasswordReset = false
     @State var isAcceptingLatestTerms = false
+    @State private var isRefreshingAccount = false
+    @State private var lastAccountRefreshDate: Date?
 
     init(viewModel: AuthViewModel) {
         self._authViewModel = ObservedObject(wrappedValue: viewModel)
@@ -35,7 +38,15 @@ struct AccountView: View {
                         detail: accountSummaryContent.detail,
                         iconSystemName: accountSummaryContent.iconSystemName,
                         providerDescription: accountSummaryContent.providerDescription,
-                        userID: accountSummaryContent.userID
+                        userID: accountSummaryContent.userID,
+                        copyEmail: copyableEmail,
+                        copyUserID: authViewModel.currentUID,
+                        onCopyEmail: { value in
+                            copyToPasteboard(value, toastMessage: "Email copied.")
+                        },
+                        onCopyUserID: { value in
+                            copyToPasteboard(value, toastMessage: "User ID copied.")
+                        }
                     )
                 }
 
@@ -90,7 +101,9 @@ struct AccountView: View {
 
                                     switch await authViewModel.sendPasswordResetForCurrentUser() {
                                     case .sent(let email):
-                                        passwordResetFeedback = .success("Password reset link sent to \(email).")
+                                        passwordResetFeedback = .success(
+                                            "Password reset link sent to \(email). Check your inbox."
+                                        )
                                         authViewModel.errorMessage = nil
                                     case .unavailable:
                                         passwordResetFeedback = .error("Password reset is only available for email sign in.")
@@ -111,6 +124,7 @@ struct AccountView: View {
                             ),
                             acceptedTermsVersionText: authViewModel.acceptedTermsVersionText,
                             acceptedPrivacyVersionText: authViewModel.acceptedPrivacyVersionText,
+                            lastCheckedText: accountLastCheckedText,
                             shouldShowAcceptLatest: authViewModel.isAcceptedTermsOutdated
                             || authViewModel.acceptedTermsSummaryText == nil,
                             isAuthenticating: isAcceptingLatestTerms,
@@ -164,6 +178,26 @@ struct AccountView: View {
                 }
             }
             .navigationTitle("Account")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        Task { await refreshAccountState(showToast: true) }
+                    } label: {
+                        if isRefreshingAccount {
+                            ProgressView()
+                                .controlSize(.small)
+                        } else {
+                            Label("Refresh account", systemImage: "arrow.clockwise")
+                        }
+                    }
+                    .disabled(
+                        isRefreshingAccount
+                        || authViewModel.isAuthenticating
+                        || !authViewModel.isSignedIn
+                    )
+                    .accessibilityLabel("Refresh account")
+                }
+            }
             .sheet(isPresented: $isShowingChangeEmailSheet) {
                 ChangeEmailSheet(
                     currentEmail: authViewModel.currentUserEmail,
@@ -181,11 +215,11 @@ struct AccountView: View {
         }
         .animation(.default, value: authViewModel.errorMessage != nil)
         .task(id: authViewModel.currentUID) {
-            await authViewModel.refreshTermsAcceptance()
+            await refreshAccountState(showToast: false)
         }
         .onChange(of: scenePhase) { _, newPhase in
             guard newPhase == .active else { return }
-            Task { await authViewModel.refreshCurrentUserFromServer() }
+            Task { await refreshAccountState(showToast: false) }
         }
     }
 
@@ -197,6 +231,41 @@ struct AccountView: View {
             providerDescription: authViewModel.authProviderDescription,
             currentUID: authViewModel.currentUID
         )
+    }
+
+    private var copyableEmail: String? {
+        guard let email = authViewModel.currentUserEmail?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !email.isEmpty else {
+            return nil
+        }
+        return email
+    }
+
+    private var accountLastCheckedText: String? {
+        lastAccountRefreshDate?.formatted(date: .abbreviated, time: .shortened)
+    }
+
+    /// Refreshes server-backed account state while avoiding duplicate refresh tasks.
+    @MainActor
+    private func refreshAccountState(showToast: Bool) async {
+        guard authViewModel.isSignedIn else { return }
+        guard !isRefreshingAccount else { return }
+
+        isRefreshingAccount = true
+        defer { isRefreshingAccount = false }
+
+        await authViewModel.refreshCurrentUserFromServer()
+        lastAccountRefreshDate = Date()
+
+        if showToast {
+            toastCenter.show("Account refreshed.")
+        }
+    }
+
+    @MainActor
+    private func copyToPasteboard(_ value: String, toastMessage: String) {
+        UIPasteboard.general.string = value
+        toastCenter.show(toastMessage)
     }
 }
 

--- a/CineMate/CineMate/Features/Account/Auth/Views/AccountView.swift
+++ b/CineMate/CineMate/Features/Account/Auth/Views/AccountView.swift
@@ -7,8 +7,8 @@
 
 import SwiftUI
 
-/// Account container that orchestrates account sections, sheets, and async auth actions.
-/// Child section views stay presentation-focused while this view owns navigation and toast flows.
+/// Owns account navigation, sheet presentation, and local feedback for async auth actions.
+/// Child section views stay presentation-focused.
 struct AccountView: View {
     @ObservedObject var authViewModel: AuthViewModel
     @EnvironmentObject private var navigator: AppNavigator
@@ -21,11 +21,11 @@ struct AccountView: View {
     @State var legalFeedback: AccountInlineFeedback?
     @State var isSendingPasswordReset = false
     @State var isAcceptingLatestTerms = false
-    
+
     init(viewModel: AuthViewModel) {
         self._authViewModel = ObservedObject(wrappedValue: viewModel)
     }
-    
+
     var body: some View {
         ZStack {
             Form {
@@ -38,8 +38,11 @@ struct AccountView: View {
                         userID: accountSummaryContent.userID
                     )
                 }
-                
-                if let errorMessage = authViewModel.errorMessage, changeEmailFeedback == nil, passwordResetFeedback == nil, legalFeedback == nil {
+
+                if let errorMessage = authViewModel.errorMessage,
+                   changeEmailFeedback == nil,
+                   passwordResetFeedback == nil,
+                   legalFeedback == nil {
                     Section {
                         AccountErrorMessageView(
                             message: errorMessage,
@@ -49,7 +52,7 @@ struct AccountView: View {
                         )
                     }
                 }
-                
+
                 if authViewModel.isSignedIn {
                     if authViewModel.isGuest {
                         GuestAccountSectionView(
@@ -59,10 +62,14 @@ struct AccountView: View {
                             }
                         )
                     }
-                    
+
                     if !authViewModel.isGuest {
                         AccountSecuritySectionView(
                             currentEmail: authViewModel.currentUserEmail,
+                            status: AccountSecurityStatus(
+                                canChangeEmail: authViewModel.canChangeEmail,
+                                canSendPasswordReset: authViewModel.canSendPasswordReset
+                            ),
                             canChangeEmail: authViewModel.canChangeEmail,
                             canSendPasswordReset: authViewModel.canSendPasswordReset,
                             isAuthenticating: isSendingPasswordReset,
@@ -80,7 +87,7 @@ struct AccountView: View {
                                     isSendingPasswordReset = true
                                     passwordResetFeedback = nil
                                     defer { isSendingPasswordReset = false }
-                                    
+
                                     switch await authViewModel.sendPasswordResetForCurrentUser() {
                                     case .sent(let email):
                                         passwordResetFeedback = .success("Password reset link sent to \(email).")
@@ -95,9 +102,15 @@ struct AccountView: View {
                                 }
                             }
                         )
-                        
+
                         AccountLegalSectionView(
-                            summaryText: authViewModel.acceptedTermsSummaryText,
+                            status: AccountLegalStatus(
+                                summaryText: authViewModel.acceptedTermsSummaryText,
+                                acceptedAtText: authViewModel.acceptedTermsAtText,
+                                isOutdated: authViewModel.isAcceptedTermsOutdated
+                            ),
+                            acceptedTermsVersionText: authViewModel.acceptedTermsVersionText,
+                            acceptedPrivacyVersionText: authViewModel.acceptedPrivacyVersionText,
                             shouldShowAcceptLatest: authViewModel.isAcceptedTermsOutdated
                             || authViewModel.acceptedTermsSummaryText == nil,
                             isAuthenticating: isAcceptingLatestTerms,
@@ -112,14 +125,14 @@ struct AccountView: View {
                                     isAcceptingLatestTerms = true
                                     legalFeedback = nil
                                     defer { isAcceptingLatestTerms = false }
-                                    
+
                                     let result = await authViewModel.acceptCurrentTermsVersion()
                                     handleAcceptTermsResult(result)
                                 }
                             }
                         )
                     }
-                    
+
                     AccountSessionSectionView(
                         isGuest: authViewModel.isGuest,
                         isAuthenticating: authViewModel.isAuthenticating,
@@ -133,7 +146,7 @@ struct AccountView: View {
                             }
                         }
                     )
-                    
+
                     if !authViewModel.isGuest {
                         AccountDangerZoneView(
                             authViewModel: authViewModel,
@@ -175,7 +188,7 @@ struct AccountView: View {
             Task { await authViewModel.refreshCurrentUserFromServer() }
         }
     }
-    
+
     private var accountSummaryContent: AccountSummaryContent {
         AccountSummaryContent(
             isSignedIn: authViewModel.isSignedIn,


### PR DESCRIPTION
## Summary

This PR improves the Account tab UI, feedback, and structure.

## Changes

- add a clearer account summary section
- add guest account upgrade section with feature benefits
- add separate security, legal, session, and danger zone sections
- move account summary content into its own model
- move feedback handling into AccountView+Feedback
- add inline feedback for email change, password reset, and terms actions
- replace full screen auth error overlay with inline account error
- add loading states for password reset and accepting latest terms
- add legal status for accepted, outdated, and missing states
- show legal status with icon, tint, terms version, privacy version, and accepted date
- add security status for email account controls
- add copy email and copy user id actions with toast feedback
- add refresh account button with loading state
- show last checked metadata in the legal section
- improve danger zone layout, copy, tint, and delete alert
- register new account files in the Xcode project

## Notes

- AccountView now owns navigation, sheets, refresh, copy actions, and async feedback.
- Child views focus on account section layout and display.