### PR TITLE
feat(app): add portfolio demo mode

### DIFF
--- a/CineMate/CineMate.xcodeproj/FirebaseConfig-README.md
+++ b/CineMate/CineMate.xcodeproj/FirebaseConfig-README.md
@@ -1,6 +1,16 @@
 # Firebase Configuration
 
-This file explains how the Firebase plist should be handled in this project.
+This file explains how local configuration is handled in this project.
+
+## Portfolio Demo
+
+The shared `CineMate` scheme uses `CINEMATE_RUNTIME=auto`.
+
+- If both local plist files exist, the app starts in live mode.
+- If either file is missing, the app starts in a local portfolio demo.
+- The demo uses sample data and does not initialize Firebase or call the TMDB API.
+
+A clean clone therefore builds and runs without personal configuration.
 
 ## Valid Path In Repo
 
@@ -14,17 +24,16 @@ This file is git-ignored and should not be committed.
 
 1. Download `GoogleService-Info.plist` from Firebase Console (Project settings -> Your apps -> iOS app).
 2. Place the file in `CineMate/Core/Config/`.
-3. Ensure the file is included in the app target in Xcode.
-4. Verify that the URL scheme in `CineMate/Info.plist` matches `REVERSED_CLIENT_ID` from the plist.
+3. Copy `Secrets.example.plist` to `CineMate/Features/Resources/Secrets.plist` and add your TMDB key.
+4. Verify that the URL scheme in `CineMate/Info.plist` matches `REVERSED_CLIENT_ID` from the Firebase plist.
+5. Run the shared `CineMate` scheme. The build copies existing local plist files into the app bundle.
 
-## Optional Build Check
+Both real plist files are git-ignored and should not be committed.
 
-Add a Run Script in Build Phases to fail clearly when the plist is missing:
+## Runtime Override
 
-```sh
-FILE="${SRCROOT}/CineMate/Core/Config/GoogleService-Info.plist"
-if [ ! -f "$FILE" ]; then
-  echo "error: Missing GoogleService-Info.plist. Download it from Firebase Console and place it at $FILE"
-  exit 1
-fi
-```
+Set `CINEMATE_RUNTIME` in an Xcode scheme when an explicit mode is useful:
+
+- `demo` always uses local sample data.
+- `live` uses live services when both plist files exist and otherwise falls back to demo.
+- `auto` selects live only when both plist files exist.

--- a/CineMate/CineMate.xcodeproj/project.pbxproj
+++ b/CineMate/CineMate.xcodeproj/project.pbxproj
@@ -68,7 +68,6 @@
 		033CAA062E623A55009514D0 /* GoogleAuthClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033CAA052E623A55009514D0 /* GoogleAuthClient.swift */; };
 		033CAA082E624B0C009514D0 /* UIKit+TopMost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033CAA072E624B0C009514D0 /* UIKit+TopMost.swift */; };
 		033CAA0A2E6251D6009514D0 /* GoogleSignInBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033CAA092E6251D6009514D0 /* GoogleSignInBootstrap.swift */; };
-		033DE9762E0144B4009FB949 /* Secrets.plist in Resources */ = {isa = PBXBuildFile; fileRef = 033DE9752E0144B4009FB949 /* Secrets.plist */; };
 		033DE9782E01FBFC009FB949 /* CastCarouselView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033DE9772E01FBFC009FB949 /* CastCarouselView.swift */; };
 		033EC7592E1D511A00B0BE08 /* SearchError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033EC7582E1D511A00B0BE08 /* SearchError.swift */; };
 		034014FB2E31781200089026 /* MovieGenresView+Previews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034014FA2E31781200089026 /* MovieGenresView+Previews.swift */; };
@@ -142,7 +141,6 @@
 		036E06B22E5B9BAB006BBA92 /* PreviewFactory+ResetPassword.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036E06B12E5B9BAB006BBA92 /* PreviewFactory+ResetPassword.swift */; };
 		036E06B42E5BA418006BBA92 /* ResetPasswordSheet+Previews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036E06B32E5BA418006BBA92 /* ResetPasswordSheet+Previews.swift */; };
 		0371433A2E7200F200A35E04 /* TermSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 037143392E7200F200A35E04 /* TermSheet.swift */; };
-		03757F132E60F2A800C5C2C1 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03757F122E60F2A800C5C2C1 /* GoogleService-Info.plist */; };
 		0381F4D32DFA261400AC2ABB /* MovieGenresView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0381F4D22DFA261400AC2ABB /* MovieGenresView.swift */; };
 		0384BD6D2E11318D00790AA5 /* PersonLinksView+Previews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0384BD6C2E11318D00790AA5 /* PersonLinksView+Previews.swift */; };
 		0384BD6F2E1177ED00790AA5 /* SocialLinkButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0384BD6E2E1177ED00790AA5 /* SocialLinkButtonView.swift */; };
@@ -356,7 +354,6 @@
 		033CAA052E623A55009514D0 /* GoogleAuthClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAuthClient.swift; sourceTree = "<group>"; };
 		033CAA072E624B0C009514D0 /* UIKit+TopMost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIKit+TopMost.swift"; sourceTree = "<group>"; };
 		033CAA092E6251D6009514D0 /* GoogleSignInBootstrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleSignInBootstrap.swift; sourceTree = "<group>"; };
-		033DE9752E0144B4009FB949 /* Secrets.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Secrets.plist; path = CineMate/Features/Resources/Secrets.plist; sourceTree = SOURCE_ROOT; };
 		033DE9772E01FBFC009FB949 /* CastCarouselView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CastCarouselView.swift; sourceTree = "<group>"; };
 		033EC7582E1D511A00B0BE08 /* SearchError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchError.swift; sourceTree = "<group>"; };
 		034014FA2E31781200089026 /* MovieGenresView+Previews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MovieGenresView+Previews.swift"; sourceTree = "<group>"; };
@@ -428,7 +425,6 @@
 		036E06B12E5B9BAB006BBA92 /* PreviewFactory+ResetPassword.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PreviewFactory+ResetPassword.swift"; sourceTree = "<group>"; };
 		036E06B32E5BA418006BBA92 /* ResetPasswordSheet+Previews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ResetPasswordSheet+Previews.swift"; sourceTree = "<group>"; };
 		037143392E7200F200A35E04 /* TermSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermSheet.swift; sourceTree = "<group>"; };
-		03757F122E60F2A800C5C2C1 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		0381F4D22DFA261400AC2ABB /* MovieGenresView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieGenresView.swift; sourceTree = "<group>"; };
 		0384BD6C2E11318D00790AA5 /* PersonLinksView+Previews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersonLinksView+Previews.swift"; sourceTree = "<group>"; };
 		0384BD6E2E1177ED00790AA5 /* SocialLinkButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialLinkButtonView.swift; sourceTree = "<group>"; };
@@ -678,7 +674,6 @@
 			isa = PBXGroup;
 			children = (
 				030612242DF4BEB40013F7AF /* Assets.xcassets */,
-				033DE9752E0144B4009FB949 /* Secrets.plist */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -835,7 +830,6 @@
 			isa = PBXGroup;
 			children = (
 				030612462DF4C05C0013F7AF /* SecretManager.swift */,
-				03757F122E60F2A800C5C2C1 /* GoogleService-Info.plist */,
 			);
 			path = Config;
 			sourceTree = "<group>";
@@ -1632,6 +1626,7 @@
 				030612002DF4BA4B0013F7AF /* Frameworks */,
 				03F7D0A92E73A00100A1B2C3 /* SwiftLint */,
 				030612012DF4BA4B0013F7AF /* Resources */,
+				D4A100002F8B000100C0FFEE /* Copy Local Configuration */,
 			);
 			buildRules = (
 			);
@@ -1716,8 +1711,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				03757F132E60F2A800C5C2C1 /* GoogleService-Info.plist in Resources */,
-				033DE9762E0144B4009FB949 /* Secrets.plist in Resources */,
 				030612292DF4BEB40013F7AF /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1750,6 +1743,25 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "export PATH=\"/opt/homebrew/bin:/usr/local/bin:${PATH}\"\n\nSWIFTLINT=\"\"\nif command -v swiftlint > /dev/null 2>&1\nthen\n  SWIFTLINT=\"$(command -v swiftlint)\"\nelif [ -x \"/opt/homebrew/bin/swiftlint\" ]\nthen\n  SWIFTLINT=\"/opt/homebrew/bin/swiftlint\"\nelif [ -x \"/usr/local/bin/swiftlint\" ]\nthen\n  SWIFTLINT=\"/usr/local/bin/swiftlint\"\nfi\n\nif [ -n \"${SWIFTLINT}\" ]\nthen\n  if ! \"${SWIFTLINT}\" lint --no-cache --config \"${SRCROOT}/.swiftlint.yml\"\n  then\n    echo \"warning: SwiftLint found violations. Build is not blocked\"\n  fi\nelse\n  echo \"warning: SwiftLint is not installed. Install with Homebrew using brew install swiftlint\"\nfi\n";
+		};
+		D4A100002F8B000100C0FFEE /* Copy Local Configuration */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Local Configuration";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/bin/bash \"${SRCROOT}/tool/copy_local_config.sh\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/CineMate/CineMate.xcodeproj/xcshareddata/xcschemes/CineMate.xcscheme
+++ b/CineMate/CineMate.xcodeproj/xcshareddata/xcschemes/CineMate.xcscheme
@@ -76,6 +76,13 @@
             ReferencedContainer = "container:CineMate.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "CINEMATE_RUNTIME"
+            value = "auto"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/CineMate/CineMate/CineMateApp.swift
+++ b/CineMate/CineMate/CineMateApp.swift
@@ -9,37 +9,18 @@ import SwiftUI
 import Foundation
 import AppIntents
 
-/// CineMateApp — DI root & bootstrap
-///
-/// What this app struct is responsible for:
-/// - Configure SDKs **once** on launch (skips Xcode Previews).
-///   1) `FirebaseBootstrap.ensureConfigured()`
-///   2) `GoogleSignInBootstrap.ensureConfigured()` (uses Firebase clientID)
-/// - Build shared services as `let` (e.g. `MovieRepository`, `FirebaseAuthService`)
-/// - Create and own long-lived view models as `@StateObject`
-/// - Switch UI:
-///   • **Signed out** --> `LoginView` flow
-///   • **Signed in**  --> `RootView` (tab bar)
-/// - Inject environment objects intentionally:
-///   • both auth branches receive `ToastCenter`
-///   • `AppNavigator` is shared app-wide (used by signed-in flow)
-/// - Handle Google sign-in callback via `.handleGoogleSignInURL()`
-///
-/// Notes:
-/// - View models are created in `init()` so they keep identity across view reloads.
-/// - Services are injected into view models (Simple DI).
+/// Application composition root for live and demo dependencies.
+/// Live mode configures Firebase before Google Sign-In. Demo mode uses local
+/// repositories and bypasses authentication. Shared view models live for the
+/// app lifetime, and navigation resets when the authentication gate changes.
 @main
 struct CineMate: App {
-    // Global enum-based navigation (bound to `NavigationStack` in RootView)
     @StateObject private var navigator = AppNavigator()
-    
-    // Lightweight global toast service
     @StateObject private var toastCenter = ToastCenter()
-    
-    // Shared services (network/auth)
-    private let authService: FirebaseAuthService
-    
-    // Long-lived view models (owned by the App)
+
+    private let runtimeMode: AppRuntimeMode
+    private let authService: FirebaseAuthService?
+
     @StateObject private var movieViewModel: MovieViewModel
     @StateObject private var castViewModel: CastViewModel
     @StateObject private var searchViewModel: SearchViewModel
@@ -49,33 +30,53 @@ struct CineMate: App {
     @StateObject private var favoritePeopleViewModel: FavoritePeopleViewModel
     @StateObject private var authViewModel: AuthViewModel
     
-    /// Build the DI graph (services -> view models).
-    /// `@StateObject` ensures each VM is created once and reused.
+    /// Builds the dependency graph for the selected runtime mode.
+    /// State objects preserve the view models for the app lifetime.
     init() {
-        // Order is enforced once at app-level bootstrap.
-        AppBootstrap.ensureConfigured()
-        
-        let repo = MovieRepository()
-        let auth = FirebaseAuthService()
-        let authVM = AuthViewModel(service: auth)
+        let mode = AppRuntimeMode.current
+        let repo: MovieProtocol
+        let auth: FirebaseAuthService?
+        let authVM: AuthViewModel
+        let favoriteMoviesVM: FavoriteMoviesViewModel
+        let favoritePeopleVM: FavoritePeopleViewModel
+
+        switch mode {
+        case .demo:
+            repo = MockMovieRepository()
+            auth = nil
+            authVM = AuthViewModel(simulatedUID: AppRuntimeMode.demoUserID)
+            favoriteMoviesVM = .preview(
+                with: Array(SharedPreviewMovies.moviesList.prefix(2))
+            )
+            favoritePeopleVM = FavoritePeopleViewModel(
+                preview: FavoritePeoplePreviewData.few()
+            )
+
+        case .live:
+            // Firebase must be configured before auth services are created.
+            AppBootstrap.ensureConfigured()
+            let liveAuth = FirebaseAuthService()
+            repo = MovieRepository()
+            auth = liveAuth
+            authVM = AuthViewModel(service: liveAuth)
+            favoriteMoviesVM = FavoriteMoviesViewModel(authService: liveAuth)
+            favoritePeopleVM = FavoritePeopleViewModel(
+                auth: liveAuth,
+                repo: FirestoreFavoritePeopleRepository()
+            )
+        }
+
+        runtimeMode = mode
         self.authService = auth
-        
-        // Create VMs that depend on the shared services
+
         _movieViewModel          = StateObject(wrappedValue: MovieViewModel(repository: repo))
         _castViewModel           = StateObject(wrappedValue: CastViewModel(repository: repo))
         _discoverViewModel       = StateObject(wrappedValue: DiscoverViewModel(repository: repo))
         _personViewModel         = StateObject(wrappedValue: PersonViewModel(repository: repo))
-        _favoritePeopleViewModel = StateObject(
-            wrappedValue: FavoritePeopleViewModel(
-                auth: auth,
-                repo: FirestoreFavoritePeopleRepository()
-            )
-        )
+        _favoritePeopleViewModel = StateObject(wrappedValue: favoritePeopleVM)
         _authViewModel           = StateObject(wrappedValue: authVM)
         _searchViewModel         = StateObject(wrappedValue: SearchViewModel(repository: repo))
-        _favoriteMoviesViewModel = StateObject(
-            wrappedValue: FavoriteMoviesViewModel(authService: auth)
-        )
+        _favoriteMoviesViewModel = StateObject(wrappedValue: favoriteMoviesVM)
     }
     
     var body: some Scene {
@@ -86,17 +87,15 @@ struct CineMate: App {
                 .onChange(of: authViewModel.currentUID) { oldUID, newUID in
                     handleSessionTransition(from: oldUID, to: newUID)
                 }
-            // App-wide Google sign-in redirect handler
                 .handleGoogleSignInURL()
         }
     }
     
     @ViewBuilder
     private var appRoot: some View {
-        switch authGateState {
-        case .signedIn:
+        if runtimeMode == .demo || authGateState == .signedIn {
             signedInRoot
-        case .signedOut:
+        } else if let authService {
             SignedOutRootView(authService: authService, onSignedIn: handleSignIn)
         }
     }
@@ -115,7 +114,8 @@ struct CineMate: App {
             personVM: personViewModel,
             favoritePeopleVM: favoritePeopleViewModel,
             authViewModel: authViewModel,
-            authService: authService
+            authService: authService,
+            isDemoMode: runtimeMode == .demo
         )
     }
     
@@ -145,9 +145,51 @@ struct CineMate: App {
     }
 }
 
-private enum AuthGateState {
+private enum AuthGateState: Equatable {
     case signedOut
     case signedIn
+}
+
+/// Selects live dependencies only when both local configuration files are bundled.
+/// Demo mode always uses local data. Live mode falls back to demo when configuration is incomplete.
+enum AppRuntimeMode: Equatable {
+    case demo
+    case live
+
+    static let environmentKey = "CINEMATE_RUNTIME"
+    static let demoUserID = "cinemate-demo-user"
+
+    static var current: AppRuntimeMode {
+        resolve(
+            environment: ProcessInfo.processInfo.environment,
+            hasLiveConfiguration: LiveConfiguration.isAvailable
+        )
+    }
+
+    static func resolve(
+        environment: [String: String],
+        hasLiveConfiguration: Bool
+    ) -> AppRuntimeMode {
+        let requestedMode = environment[environmentKey]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+
+        switch requestedMode {
+        case "demo":
+            return .demo
+        case "live":
+            return hasLiveConfiguration ? .live : .demo
+        default:
+            return hasLiveConfiguration ? .live : .demo
+        }
+    }
+}
+
+private enum LiveConfiguration {
+    static var isAvailable: Bool {
+        Bundle.main.url(forResource: "Secrets", withExtension: "plist") != nil
+        && Bundle.main.url(forResource: "GoogleService-Info", withExtension: "plist") != nil
+    }
 }
 
 private enum SignedOutRoute: Hashable {

--- a/CineMate/CineMate/Core/Navigation/RootView.swift
+++ b/CineMate/CineMate/Core/Navigation/RootView.swift
@@ -7,9 +7,6 @@
 
 import SwiftUI
 
-/// Root screen for tabs and app navigation.
-/// Uses one shared `NavigationStack` with `AppNavigator`.
-/// Shows lock overlays for guest users on protected tabs.
 private enum MainTab: String, Hashable {
     case movies
     case favorites
@@ -18,13 +15,14 @@ private enum MainTab: String, Hashable {
     case auth
 }
 
+/// Hosts shared tab navigation and keeps a separate route path for each tab.
+/// It syncs favorites with the auth session and gates protected features for guests.
 struct RootView: View {
     @EnvironmentObject private var navigator: AppNavigator
     @EnvironmentObject private var toastCenter: ToastCenter
     @State private var selectedTab: MainTab = .movies
     @State private var tabPaths: [MainTab: [AppRoute]] = [:]
 
-    // View models are injected from the app root.
     let movieVM: MovieViewModel
     let castVM: CastViewModel
     let favVM: FavoriteMoviesViewModel
@@ -33,7 +31,8 @@ struct RootView: View {
     let personVM: PersonViewModel
     let favoritePeopleVM: FavoritePeopleViewModel
     let authViewModel: AuthViewModel
-    let authService: FirebaseAuthService
+    let authService: FirebaseAuthService?
+    let isDemoMode: Bool
 
     var body: some View {
         NavigationStack(path: $navigator.path) {
@@ -50,12 +49,11 @@ struct RootView: View {
                 favoritePeopleVM.syncAuthState(uid: authViewModel.currentUID)
             }
 
-            // Save the path for the active tab.
+            // Preserve route history independently for each tab.
             .onChange(of: navigator.path) { _, newPath in
                 tabPaths[selectedTab] = newPath
             }
 
-            // Restore the path when the tab changes.
             .onChange(of: selectedTab) { oldTab, newTab in
                 guard oldTab != newTab else { return }
                 tabPaths[oldTab] = navigator.path
@@ -66,7 +64,6 @@ struct RootView: View {
                 )
             }
 
-            // Build a destination for each route.
             .navigationDestination(for: AppRoute.self) { route in
                 destination(for: route)
             }
@@ -77,7 +74,7 @@ struct RootView: View {
             tabPaths[selectedTab] = navigator.path
         }
         .onDisappear {
-            // RootView only exists in signed-in flow, so clear state on teardown.
+            // Release listeners and clear session-scoped favorites on teardown.
             favVM.stopFavoritesListenerIfNeeded(keepCurrentState: false)
             favoritePeopleVM.stopFavoritesListenerIfNeeded(keepCurrentState: false)
         }
@@ -131,7 +128,13 @@ extension RootView {
     }
 
     private var accountTab: some View {
-        AccountView(viewModel: authViewModel)
+        Group {
+            if isDemoMode {
+                DemoAccountView()
+            } else {
+                AccountView(viewModel: authViewModel)
+            }
+        }
             .tabItem { Label("Account", systemImage: "person.crop.circle") }
             .tag(MainTab.auth)
     }
@@ -173,16 +176,24 @@ extension RootView {
             )
 
         case .createAccount:
-            // Signed in users can still upgrade anonymous accounts.
-            CreateAccountView(
-                createViewModel: CreateAccountViewModel(
-                    service: authService,
-                    onVerificationEmailSent: {
-                        toastCenter.show("Check your inbox to verify your email")
-                        navigator.goBack()
-                    }
+            if let authService {
+                // Signed in users can still upgrade anonymous accounts.
+                CreateAccountView(
+                    createViewModel: CreateAccountViewModel(
+                        service: authService,
+                        onVerificationEmailSent: {
+                            toastCenter.show("Check your inbox to verify your email")
+                            navigator.goBack()
+                        }
+                    )
                 )
-            )
+            } else {
+                ContentUnavailableView(
+                    "Unavailable in Demo",
+                    systemImage: "person.crop.circle.badge.plus",
+                    description: Text("Account creation requires the local Firebase configuration.")
+                )
+            }
         }
     }
 
@@ -191,6 +202,29 @@ extension RootView {
         ?? castVM.crew.first(where: { $0.id == id }).map(CastMember.init(from:))
         ?? favoritePeopleVM.favorites.first(where: { $0.id == id }).map(CastMember.init(from:))
         ?? CastMember(id: id, name: "", character: nil, profilePath: nil)
+    }
+}
+
+private struct DemoAccountView: View {
+    var body: some View {
+        Form {
+            Section {
+                Label("Demo mode", systemImage: "sparkles")
+                    .font(.headline)
+
+                Text(
+                    "Explore CineMate with local sample data. "
+                    + "Favorites stay in memory and no account is connected."
+                )
+                .foregroundStyle(.secondary)
+            }
+
+            Section("Portfolio Demo") {
+                LabeledContent("Data", value: "Local samples")
+                LabeledContent("Account", value: "Not connected")
+            }
+        }
+        .navigationTitle("Account")
     }
 }
 

--- a/CineMate/CineMateTests/SearchValidatorTests.swift
+++ b/CineMate/CineMateTests/SearchValidatorTests.swift
@@ -95,6 +95,52 @@ final class AuthValidatorTests: XCTestCase {
     }
 }
 
+final class AppRuntimeModeTests: XCTestCase {
+    func testMissingConfigurationDefaultsToDemo() {
+        XCTAssertEqual(
+            AppRuntimeMode.resolve(environment: [:], hasLiveConfiguration: false),
+            .demo
+        )
+    }
+
+    func testAvailableConfigurationDefaultsToLive() {
+        XCTAssertEqual(
+            AppRuntimeMode.resolve(environment: [:], hasLiveConfiguration: true),
+            .live
+        )
+    }
+
+    func testDemoOverrideWinsWhenConfigurationExists() {
+        XCTAssertEqual(
+            AppRuntimeMode.resolve(
+                environment: [AppRuntimeMode.environmentKey: "demo"],
+                hasLiveConfiguration: true
+            ),
+            .demo
+        )
+    }
+
+    func testLiveOverrideFallsBackToDemoWithoutConfiguration() {
+        XCTAssertEqual(
+            AppRuntimeMode.resolve(
+                environment: [AppRuntimeMode.environmentKey: "live"],
+                hasLiveConfiguration: false
+            ),
+            .demo
+        )
+    }
+
+    func testLiveOverrideUsesLiveWhenConfigurationExists() {
+        XCTAssertEqual(
+            AppRuntimeMode.resolve(
+                environment: [AppRuntimeMode.environmentKey: " LIVE "],
+                hasLiveConfiguration: true
+            ),
+            .live
+        )
+    }
+}
+
 final class EnumBackedMappingTests: XCTestCase {
     func testPersonDetailGenderTextKeepsKnownAndUnknownMappings() {
         XCTAssertEqual(personDetail(gender: 1).safeGenderText, "Female")

--- a/CineMate/tool/copy_local_config.sh
+++ b/CineMate/tool/copy_local_config.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly destination="${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
+
+copy_if_present() {
+    local source="$1"
+    local filename="$2"
+
+    if [[ -f "${source}" ]]; then
+        /bin/mkdir -p "${destination}"
+        /bin/cp "${source}" "${destination}/${filename}"
+        echo "Copied local ${filename}"
+    else
+        /bin/rm -f "${destination}/${filename}"
+        echo "Local ${filename} not found; portfolio demo mode remains available"
+    fi
+}
+
+copy_if_present \
+    "${SRCROOT}/CineMate/Features/Resources/Secrets.plist" \
+    "Secrets.plist"
+
+copy_if_present \
+    "${SRCROOT}/CineMate/Core/Config/GoogleService-Info.plist" \
+    "GoogleService-Info.plist"

--- a/README.md
+++ b/README.md
@@ -72,7 +72,19 @@ Open the Xcode project:
 open CineMate/CineMate.xcodeproj
 ```
 
-Select the shared `CineMate` scheme, choose an iOS simulator, and run. A clean clone automatically starts in demo mode without an Apple Developer account, Firebase project, or TMDB credentials.
+Select the shared `CineMate` scheme, choose an iOS simulator, and run. A clean clone automatically starts in portfolio demo mode without an Apple Developer account, Firebase project, or TMDB credentials.
+
+## Portfolio Demo Mode
+
+CineMate is designed to be easy to review from a clean clone. The shared scheme uses `CINEMATE_RUNTIME=auto`, so the app chooses the safest runtime at launch:
+
+- `auto` starts live mode only when both local plist files are present.
+- `demo` always uses local sample data.
+- `live` uses live services when the plist files are present, and falls back to demo when they are missing.
+
+In portfolio demo mode, the app does not configure Firebase or call the TMDB API. Movie data, people data, and favorites come from local sample fixtures. Favorites stay in memory for the current run, and the Account tab clearly shows that no account is connected.
+
+For portfolio review, no extra setup is needed: open the project, run the shared scheme, and browse the app. Add the ignored plist files only when you want to test live authentication, TMDB requests, and Firestore-backed favorites.
 
 ## Optional Live Setup
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ The project is built to show production-oriented iOS fundamentals: clear feature
 |---|---|
 | <img src="CineMate/Docs/Media/cinemate-favorite-movies.jpg" width="220" alt="CineMate favorite movies list backed by Firestore" /> | <img src="CineMate/Docs/Media/cinemate-favorite-people.jpg" width="220" alt="CineMate favorite people grid backed by Firestore" /> |
 
+The shared `CineMate` scheme also includes a self-contained portfolio demo. It uses local sample data when the ignored Firebase and TMDB plist files are not available.
+
 ## Highlights
 
 - SwiftUI app with tab-based navigation, typed routes, and shared navigation state.
@@ -57,12 +59,25 @@ The project is built to show production-oriented iOS fundamentals: clear feature
 └── README.md                         # This file
 ```
 
-## Setup
+## Quick Start (No Secrets)
 
 ### Requirements
 
 - Xcode with Swift Package Manager support.
 - iOS 17.6+ simulator or device.
+
+Open the Xcode project:
+
+```sh
+open CineMate/CineMate.xcodeproj
+```
+
+Select the shared `CineMate` scheme, choose an iOS simulator, and run. A clean clone automatically starts in demo mode without an Apple Developer account, Firebase project, or TMDB credentials.
+
+## Optional Live Setup
+
+Live services and Firestore rules tests additionally require:
+
 - Firebase project with Authentication and Firestore enabled.
 - TMDB API credentials.
 - Node.js and Firebase CLI for Firestore rules tests.
@@ -100,7 +115,7 @@ Also verify that the URL scheme in `CineMate/CineMate/Info.plist` matches the `R
 
 More Firebase setup notes live in [`CineMate/CineMate.xcodeproj/FirebaseConfig-README.md`](CineMate/CineMate.xcodeproj/FirebaseConfig-README.md).
 
-### 3. Run the App
+### 3. Run with Live Services
 
 Open the Xcode project:
 
@@ -108,7 +123,7 @@ Open the Xcode project:
 open CineMate/CineMate.xcodeproj
 ```
 
-Select the shared `CineMate` scheme, choose an iOS simulator or device, and run.
+Select the shared `CineMate` scheme, choose an iOS simulator or device, and run. When both local plist files exist, the scheme automatically starts the live dependencies.
 
 ## Verification
 


### PR DESCRIPTION
## Summary

- add app runtime mode for auto, demo, and live startup.
- use mock movie data, sample favorites, and simulated auth in demo.
- skip firebase setup and tmdb calls when demo mode is active.
- show a demo account tab when no live auth service is available.
- copy local firebase and tmdb plist files during xcode builds.
- remove ignored plist files from direct project resources.
- document clean clone demo setup and optional live setup.
- add runtime mode tests for config defaults and overrides.